### PR TITLE
Draft with one resource publishing

### DIFF
--- a/ckanext/unhcr/controllers/extended_package.py
+++ b/ckanext/unhcr/controllers/extended_package.py
@@ -15,6 +15,14 @@ class ExtendedPackageController(PackageController):
             return toolkit.abort(403, toolkit.render('page.html'))
         return super(ExtendedPackageController, self).read(id)
 
+    # Publish
+
+    def publish(self, id):
+        context = {'model': model, 'user': toolkit.c.user}
+        dataset = toolkit.get_action('package_patch')(context, {'id': id, 'state': 'active'})
+        toolkit.h.flash_success('Dataset "%s" has been published' % dataset['title'])
+        toolkit.redirect_to('dataset_read', id=dataset['name'])
+
     # Copy
 
     def copy(self, id):

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -93,6 +93,7 @@ class UnhcrPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermission
 
         controller = 'ckanext.unhcr.controllers.extended_package:ExtendedPackageController'
         _map.connect('/dataset/{id}', controller=controller, action='read')
+        _map.connect('/dataset/publish/{id}', controller=controller, action='publish')
         _map.connect('/dataset/copy/{id}', controller=controller, action='copy')
         _map.connect('/dataset/{id}/resource_copy/{resource_id}', controller=controller, action='resource_copy')
         _map.connect('/dataset/{id}/resource/{resource_id}/download', controller=controller, action='resource_download')

--- a/ckanext/unhcr/templates/package/snippets/package_form.html
+++ b/ckanext/unhcr/templates/package/snippets/package_form.html
@@ -39,9 +39,16 @@ then itself be extended to add/remove blocks of functionality. #}
           <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this dataset?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
         {% endif %}
       {% endblock %}
-      {% block save_button %}
-        <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
-      {% endblock %}
+      {# To fix the problem with a draft with one resource #}
+      {# https://github.com/okfn/ckanext-unhcr/issues/206 #}
+      {% if data.state == 'draft' and data.resources %}
+        <button class="btn btn-primary" type="submit" name="save">{{ _('Add Data') }}</button>
+        <button class="btn btn-primary" name="publish">{{ _('Publish Dataset') }}</button>
+      {% else %}
+        {% block save_button %}
+          <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+        {% endblock %}
+      {% endif %}
       {{ form.required_message() }}
     </div>
   {% endblock %}

--- a/ckanext/unhcr/templates/package/snippets/package_form.html
+++ b/ckanext/unhcr/templates/package/snippets/package_form.html
@@ -43,7 +43,7 @@ then itself be extended to add/remove blocks of functionality. #}
       {# https://github.com/okfn/ckanext-unhcr/issues/206 #}
       {% if data.state == 'draft' and data.resources %}
         <button class="btn btn-primary" type="submit" name="save">{{ _('Add Data') }}</button>
-        <button class="btn btn-primary" name="publish">{{ _('Publish Dataset') }}</button>
+        <a href="/dataset/publish/{{ data.id }}" class="btn btn-primary">{{ _('Publish Dataset') }}</a>
       {% else %}
         {% block save_button %}
           <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>


### PR DESCRIPTION
- fixes #206 

---

@amercader 
Please take a look and test if possible. It looks like this now:

![draft](https://user-images.githubusercontent.com/557395/63770777-891a2e00-c8de-11e9-9a59-a12eabc885f1.png)
