### PR TITLE
[#246] Fix No data container handling

### DIFF
--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -125,7 +125,11 @@ def organization_create(context, data_dict):
 def package_create(context, data_dict):
 
     # Data deposit
-    if data_dict:
+    if not data_dict:
+        # All users can deposit datasets
+        if toolkit.request.path == '/deposited-dataset/new':
+            return {'success': True}
+    else:
         deposit = helpers.get_data_deposit()
         if deposit['id'] == data_dict.get('owner_org'):
             return {'success': True}

--- a/ckanext/unhcr/templates/package/new.html
+++ b/ckanext/unhcr/templates/package/new.html
@@ -1,0 +1,11 @@
+{% if dataset_type != 'deposited-dataset' and not h.organizations_available('create_dataset')
+        and not h.check_config_permission('ckan.auth.create_unowned_dataset') %}
+
+    {% include "package/snippets/cannot_create_package.html" %}
+
+{% else %}
+    {% extends "package/base_form_page.html" %}
+
+    {% block subtitle %}{{ _('Create Dataset') }}{% endblock %}
+{% endif  %}
+


### PR DESCRIPTION
We originally used the auth option to allow unowned datasets to be created in order to allow users to deposit datasets, but that is wrong because then normal datasets can be created unowned too.

This changes the way auth for depositing datasets is handled and reverts the auth conf change.

Also requires https://github.com/okfn/docker-ckan-unhcr/pull/19

Fixes #247 