### PR TITLE
get the test suite passing

### DIFF
--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -380,7 +380,10 @@ class TestResourceUpload(base.FunctionalTestBase):
 
         resource = factories.Resource(
             package_id=dataset['id'],
-            upload=test_upload)
+            upload=test_upload,
+            url = "http://fakeurl/test.txt",
+            url_type='upload',
+        )
 
         assert_equals(
             resource['url'],

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -401,10 +401,10 @@ class TestResourceUpload(base.FunctionalTestBase):
                 package_id=dataset['id'],
                 url='https://example.com/some.data.csv')
 
-        assert exc.exception.error_dict.keys() == ['upload']
+        assert exc.exception.error_dict.keys() == ['url']
 
         assert_equals(
-            exc.exception.error_dict['upload'],
+            exc.exception.error_dict['url'],
             ['All resources require an uploaded file'])
 
     def test_upload_missing(self):
@@ -415,8 +415,8 @@ class TestResourceUpload(base.FunctionalTestBase):
 
             factories.Resource(package_id=dataset['id'])
 
-        assert exc.exception.error_dict.keys() == ['upload']
+        assert exc.exception.error_dict.keys() == ['url']
 
         assert_equals(
-            exc.exception.error_dict['upload'],
+            exc.exception.error_dict['url'],
             ['All resources require an uploaded file'])

--- a/ckanext/unhcr/tests/test_controllers.py
+++ b/ckanext/unhcr/tests/test_controllers.py
@@ -921,7 +921,9 @@ class TestExtendedPackageController(base.FunctionalTestBase):
         # Resources
         self.resource1 = factories.Resource(
             name='resource1',
-            package_id='dataset1')
+            package_id='dataset1',
+            url_type='upload',
+        )
 
     # Helpers
 

--- a/ckanext/unhcr/tests/test_schema.py
+++ b/ckanext/unhcr/tests/test_schema.py
@@ -21,15 +21,20 @@ class TestResourceFields(base.FunctionalTestBase):
             'description': 'Some description',
             'type': 'attachment',
             'file_type': 'report',
+            'url_type': 'upload',
         }
 
         dataset['resources'] = [resource]
 
         updated_dataset = call_action('package_update', {}, **dataset)
 
-        for field in resource.keys():
+        for field in [k for k in resource.keys() if k != 'url']:
             assert_equals(
                 updated_dataset['resources'][0][field], resource[field])
+        assert_equals(
+            updated_dataset['resources'][0]['url'].split('/')[-1],
+            resource['url'].split('/')[-1]
+        )
 
         assert 'date_range_start' not in updated_dataset['resources'][0]
 


### PR DESCRIPTION
ebe612e is pretty straightforward: https://github.com/okfn/ckanext-unhcr/commit/3b249f6cf699ad51523dd690d0376c92e1a3a78a changed the key from `'upload'` to `'url'` but didn't update the test assertions.

Others are basically about resources having an associated upload.
Should be good for review