### PR TITLE
Weekly summary emails

### DIFF
--- a/ckanext/unhcr/commands.py
+++ b/ckanext/unhcr/commands.py
@@ -6,6 +6,11 @@ from ckan.plugins import toolkit
 
 import ckan.model as model
 from ckanext.unhcr.models import tables_exist, create_tables, TimeSeriesMetric
+from ckanext.unhcr.mailer import (
+    compose_summary_email_body,
+    get_summary_email_recipients,
+    mail_user_by_id
+)
 
 
 class Unhcr(toolkit.CkanCommand):
@@ -18,6 +23,9 @@ class Unhcr(toolkit.CkanCommand):
         paster unhcr snapshot-metrics
             Take a snapshot of time-series metrics
 
+        paster unhcr send-summary-emails
+            Send a summary of activity over the last 7 days
+            to sysadmins and curators
     '''
     summary = __doc__.split('\n')[0]
     usage = __doc__
@@ -39,6 +47,8 @@ class Unhcr(toolkit.CkanCommand):
             self.init_db()
         elif cmd == 'snapshot-metrics':
             self.snapshot_metrics()
+        elif cmd == 'send-summary-emails':
+            self.send_summary_emails()
         else:
             self.parser.print_usage()
             sys.exit(1)
@@ -73,3 +83,20 @@ class Unhcr(toolkit.CkanCommand):
         model.Session.commit()
         model.Session.refresh(rec)
         print('Snapshot saved at {}'.format(rec.timestamp))
+
+    def send_summary_emails(self):
+        recipients = get_summary_email_recipients()
+        subject = '[UNHCR RIDL] Weekly Summary'
+
+        for recipient in recipients:
+            if recipient['email']:
+                print('Sending summary email to: {}'.format(recipient['email']))
+
+                body = compose_summary_email_body(recipient)
+                if self.verbose > 1:
+                    print(body)
+                    print('')
+
+                mail_user_by_id(recipient['id'], subject, body)
+
+        print('Sent weekly summary emails.')

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -183,8 +183,11 @@ def get_summary_email_recipients():
     curator_ids = [c[0] for c in curators]
 
     all_users = toolkit.get_action('user_list')({ 'ignore_auth': True }, {})
+    default_user = toolkit.get_action('get_site_user')({ 'ignore_auth': True })
 
     for user in all_users:
+        if user['name'] == default_user['name']:
+            continue
         if user['sysadmin'] or user['id'] in curator_ids:
             recipients.append(user)
 

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -1,10 +1,10 @@
+from datetime import datetime, timedelta
 import logging
 from ckan import model
 from ckan.common import config
 from ckan.plugins import toolkit
 from ckan.lib import mailer as core_mailer
 from ckan.lib.base import render_jinja2
-import ckan.logic.action.get as get_core
 from ckanext.unhcr import helpers
 log = logging.getLogger(__name__)
 
@@ -79,3 +79,94 @@ def compose_membership_email_body(container, user_dict, event):
             item['url'] = toolkit.url_for('data-container_read', id=item['name'], qualified=True)
         context['container_url'] = toolkit.url_for('data-container_index', qualified=True)
     return render_jinja2('emails/membership/%s.html' % event, context)
+
+
+# Weekly Summary
+
+def _get_new_packages(context, start_time):
+    data_dict = {
+        'q': '*:*',
+        'fq': (
+            '-type:deposited-dataset AND ' +\
+            'metadata_created:[{} TO NOW]'.format(start_time)
+        ),
+        'include_private': True,
+    }
+    packages = toolkit.get_action('package_search')(context, data_dict)
+    return packages['results']
+
+
+def _get_new_deposits(context, start_time):
+    data_dict = {
+        'q': '*:*',
+        'fq': (
+            'type:deposited-dataset AND ' +\
+            '-curation_state:review AND ' +\
+            'metadata_created:[{} TO NOW]'.format(start_time)
+        ),
+        'include_private': True,
+    }
+    packages = toolkit.get_action('package_search')(context, data_dict)
+    return packages['results']
+
+
+def _get_deposits_awaiting_review(context, start_time):
+    data_dict = {
+        'q': '*:*',
+        'fq': (
+            'type:deposited-dataset AND ' +\
+            'curation_state:review AND ' +\
+            'metadata_created:[{} TO NOW]'.format(start_time)
+        ),
+        'include_private': True,
+    }
+    packages = toolkit.get_action('package_search')(context, data_dict)
+    return packages['results']
+
+
+def compose_summary_email_body(user_dict):
+    context = {}
+
+    start_time = datetime.now() - timedelta(days=7)
+    context['start_date'] = start_time.strftime('%A %B %e %Y')
+    query_start_time = start_time.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    context['recipient'] = user_dict.get('fullname') or user_dict.get('name')
+    context['site_title'] = config.get('ckan.site_title')
+    context['site_url'] = config.get('ckan.site_url')
+
+    context['datasets_url'] = toolkit.url_for('search', qualified=True)
+    context['deposits_url'] = toolkit.url_for('data-deposit', qualified=True)
+
+    action_context = { 'user': user_dict['name'] }
+    context['new_datasets'] = _get_new_packages(action_context, query_start_time)
+    context['new_deposits'] = _get_new_deposits(action_context, query_start_time)
+    context['awaiting_review'] = _get_deposits_awaiting_review(
+        action_context,
+        query_start_time
+    )
+
+    context['h'] = toolkit.h
+
+    return render_jinja2('emails/curation/summary.html', context)
+
+
+def get_summary_email_recipients():
+    # summary emails are sent to sysadmins
+    # and members of the curation team
+    recipients = []
+
+    deposit_group = helpers.get_data_deposit()
+    curators = toolkit.get_action('member_list')(
+        { 'ignore_auth': True },
+        { 'id': deposit_group['id'] }
+    )
+    curator_ids = [c[0] for c in curators]
+
+    all_users = toolkit.get_action('user_list')({ 'ignore_auth': True }, {})
+
+    for user in all_users:
+        if user['sysadmin'] or user['id'] in curator_ids:
+            recipients.append(user)
+
+    return recipients

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -90,6 +90,7 @@ def _get_new_packages(context, start_time):
             '-type:deposited-dataset AND ' +\
             'metadata_created:[{} TO NOW]'.format(start_time)
         ),
+        'sort': 'metadata_created desc',
         'include_private': True,
     }
     packages = toolkit.get_action('package_search')(context, data_dict)
@@ -104,6 +105,7 @@ def _get_new_deposits(context, start_time):
             '-curation_state:review AND ' +\
             'metadata_created:[{} TO NOW]'.format(start_time)
         ),
+        'sort': 'metadata_created desc',
         'include_private': True,
     }
     packages = toolkit.get_action('package_search')(context, data_dict)
@@ -118,6 +120,7 @@ def _get_deposits_awaiting_review(context, start_time):
             'curation_state:review AND ' +\
             'metadata_created:[{} TO NOW]'.format(start_time)
         ),
+        'sort': 'metadata_created desc',
         'include_private': True,
     }
     packages = toolkit.get_action('package_search')(context, data_dict)
@@ -135,8 +138,24 @@ def compose_summary_email_body(user_dict):
     context['site_title'] = config.get('ckan.site_title')
     context['site_url'] = config.get('ckan.site_url')
 
-    context['datasets_url'] = toolkit.url_for('search', qualified=True)
-    context['deposits_url'] = toolkit.url_for('data-deposit', qualified=True)
+    context['datasets_url'] = toolkit.url_for(
+        'search',
+        q=(
+            '-type:deposited-dataset AND ' +\
+            'metadata_created:[{} TO NOW]'.format(query_start_time)
+        ),
+        sort='metadata_created desc',
+        qualified=True
+    )
+    context['deposits_url'] = toolkit.url_for(
+        'search',
+        q=(
+            'type:deposited-dataset AND ' +\
+            'metadata_created:[{} TO NOW]'.format(query_start_time)
+        ),
+        sort='metadata_created desc',
+        qualified=True
+    )
 
     action_context = { 'user': user_dict['name'] }
     context['new_datasets'] = _get_new_packages(action_context, query_start_time)

--- a/ckanext/unhcr/templates/emails/curation/summary.html
+++ b/ckanext/unhcr/templates/emails/curation/summary.html
@@ -25,7 +25,7 @@
   {% endcall %}
 
   {% call email.action(datasets_url) %}
-    See all Datasets
+    See new Datasets
   {% endcall %}
 
   {% call email.paragraph() %}
@@ -59,7 +59,7 @@
   {% endcall %}
 
   {% call email.action(deposits_url) %}
-    Go to the Data Deposit
+    See new Data Deposits
   {% endcall %}
 
 {% endblock %}

--- a/ckanext/unhcr/templates/emails/curation/summary.html
+++ b/ckanext/unhcr/templates/emails/curation/summary.html
@@ -1,0 +1,65 @@
+{% extends "emails/curation/base.html" %}
+{% import 'macros/email.html' as email with context %}
+
+{% block email_body %}
+
+  {% call email.paragraph() %}
+    Dear <b>{{ recipient }}</b>,
+  {% endcall %}
+
+  {% call email.paragraph() %}
+    Here is a summary of the activity in the RIDL site since {{ start_date }}.
+  {% endcall %}
+
+  {% call email.paragraph() %}
+    <h1>New datasets ({{ new_datasets|length }})</h1>
+    <ul>
+    {% for ds in new_datasets %}
+      <li>
+        {{ h.link_to(ds.title or ds.name, h.url_for('dataset_read', id=ds.name, qualified=True)) }}
+      </li>
+    {% else %}
+      <li>No new datasets</li>
+    {% endfor %}
+    </ul>
+  {% endcall %}
+
+  {% call email.action(datasets_url) %}
+    See all Datasets
+  {% endcall %}
+
+  {% call email.paragraph() %}
+    <h1>Data Deposit</h1>
+  {% endcall %}
+
+  {% call email.paragraph() %}
+    <h2>New deposited datasets ({{ new_deposits|length }})</h2>
+    <ul>
+      {% for ds in new_deposits %}
+        <li>
+          {{ h.link_to(ds.title or ds.name, h.url_for('dataset_read', id=ds.name, qualified=True)) }}
+        </li>
+      {% else %}
+        <li>No new deposits</li>
+      {% endfor %}
+    </ul>
+  {% endcall %}
+
+  {% call email.paragraph() %}
+    <h2>Datasets awaiting review ({{ awaiting_review|length }})</h2>
+    <ul>
+      {% for ds in awaiting_review %}
+        <li>
+          {{ h.link_to(ds.title or ds.name, h.url_for('dataset_read', id=ds.name, qualified=True)) }}
+        </li>
+      {% else %}
+        <li>Nothing awaiting review</li>
+      {% endfor %}
+    </ul>
+  {% endcall %}
+
+  {% call email.action(deposits_url) %}
+    Go to the Data Deposit
+  {% endcall %}
+
+{% endblock %}

--- a/ckanext/unhcr/tests/test_mailer.py
+++ b/ckanext/unhcr/tests/test_mailer.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta
+import ckan.model as model
+from ckan.lib.jinja_extensions import regularise_html
+import ckan.lib.search as search
+from ckan.plugins import toolkit
+from ckan.tests import factories as core_factories
+from ckanext.unhcr.tests import base, factories
+from ckanext.unhcr.mailer import (
+    compose_summary_email_body,
+    get_summary_email_recipients
+)
+
+
+class TestMailer(base.FunctionalTestBase):
+
+    # General
+
+    def setup(self):
+        super(TestMailer, self).setup()
+
+        # Users
+        self.sysadmin = core_factories.Sysadmin(name='sysadmin', id='sysadmin')
+
+    def test_email_body(self):
+        deposit = factories.DataContainer(id='data-deposit')
+        target = factories.DataContainer(id='data-target')
+        factories.Dataset(
+            name='new-dataset',
+            title='New Dataset',
+        )
+        factories.Dataset(
+            name='new-deposit',
+            title='New Deposit',
+            type='deposited-dataset',
+            owner_org=deposit['id'],
+            owner_org_dest=target['id'],
+            curation_state='submitted',
+        )
+        factories.Dataset(
+            name='awaiting-review',
+            title='Awaiting Review',
+            type='deposited-dataset',
+            owner_org=deposit['id'],
+            owner_org_dest=target['id'],
+            curation_state='review',
+        )
+        old_dataset = factories.Dataset(
+            name='old-dataset',
+            title='Old Dataset',
+        )
+        # This is a little bit messy.
+        # We can't set the `metadata_created` property via a factory or an
+        # action and the default is set in postgres so freezegun doesn't help.
+        # So we will update the value directly using SQLAlchemy:
+        model.Session.query(model.Package).filter_by(id=old_dataset['id']).update(
+            { "metadata_created": datetime.now() - timedelta(days=8) }
+        )
+        model.Session.commit()
+        # ..and then refresh the search index
+        # so that the record is up-to-date when we query solr
+        search.rebuild(package_id=old_dataset['id'])
+
+        expected_values = [
+            '''
+            <h1>New datasets (1)</h1>
+            <ul> <li> <a href="{}">New Dataset</a> </li> </ul>'''.format(
+                toolkit.url_for('dataset_read', id='new-dataset', qualified=True)
+            ),
+
+            '''
+            <h2>New deposited datasets (1)</h2>
+            <ul> <li> <a href="{}">New Deposit</a> </li> </ul>'''.format(
+                toolkit.url_for('dataset_read', id='new-deposit', qualified=True)
+            ),
+
+            '''
+            <h2>Datasets awaiting review (1)</h2>
+            <ul> <li> <a href="{}">Awaiting Review</a> </li> </ul>'''.format(
+                toolkit.url_for('dataset_read', id='awaiting-review', qualified=True)
+            ),
+        ]
+
+        email_body = compose_summary_email_body(self.sysadmin)
+        regularised_body = regularise_html(email_body)
+
+        for ev in expected_values:
+            assert regularise_html(ev) in regularised_body
+        assert 'Old Dataset' not in regularised_body
+        assert (
+            toolkit.url_for("dataset_read", id="old-dataset", qualified=True)
+            not in regularised_body
+        )
+
+    def test_email_recipients(self):
+        user1 = core_factories.User(name='user1', id='user1')
+        curator = core_factories.User(name='curator', id='curator')
+        factories.DataContainer(
+            users=[
+                {'name': 'curator', 'capacity': 'editor'},
+            ],
+            name='data-deposit',
+            id='data-deposit'
+        )
+
+        recipients = get_summary_email_recipients()
+        recipient_ids = [r['name'] for r in recipients]
+
+        assert len(recipient_ids) == 3
+        assert curator['name'] in recipient_ids
+        assert self.sysadmin['name'] in recipient_ids
+        assert (
+            'default_test' in recipient_ids or  # local
+            'test.ckan.net' in recipient_ids  # travis
+        )
+        assert user1['name'] not in recipient_ids

--- a/ckanext/unhcr/tests/test_mailer.py
+++ b/ckanext/unhcr/tests/test_mailer.py
@@ -105,11 +105,7 @@ class TestMailer(base.FunctionalTestBase):
         recipients = get_summary_email_recipients()
         recipient_ids = [r['name'] for r in recipients]
 
-        assert len(recipient_ids) == 3
+        assert len(recipient_ids) == 2
         assert curator['name'] in recipient_ids
         assert self.sysadmin['name'] in recipient_ids
-        assert (
-            'default_test' in recipient_ids or  # local
-            'test.ckan.net' in recipient_ids  # travis
-        )
         assert user1['name'] not in recipient_ids


### PR DESCRIPTION
Refs #267

This PR adds the command to build and send summary emails.
I'll do a separate PR on the docker repo for the scheduling.


Example email:

![Screenshot at 2020-04-03 14-05-00](https://user-images.githubusercontent.com/6025893/78371972-94de7900-75c0-11ea-92d7-675d3b4193b4.png)
