### PR TITLE
Improve X-axis labelling for line charts

### DIFF
--- a/ckanext/unhcr/templates/metrics/snippets/timeseries_graph.html
+++ b/ckanext/unhcr/templates/metrics/snippets/timeseries_graph.html
@@ -11,12 +11,16 @@ document.addEventListener("DOMContentLoaded", function(event) {
         },
         x: {
           type: 'timeseries',
-          tick: { format: '%Y-%m-%d' },
+          tick: {
+            format: '%Y-%m-%d',
+            culling: { count: 12 },
+            rotate: 75,
+          },
         },
       },
       data: {
         x: 'x',
-        xFormat: '%Y-%m-%d %H:%M:%S.%f',
+        xFormat: '%Y-%m-%d',
         columns: {{ metric.data | tojson }},
       },
   });


### PR DESCRIPTION
This PR does several things to try and make this better:

1. Don't show an x-axis 'tick' (label) for every single data point: show up to a maximum of 12 regardless of the number of points.
2. Rotate the label a bit so each label consumes less horizontal space.
3. Group the timestamps by date server-side: If we've taken lots of data points on the same day, just take the last value for each date.

This should make things a bit better :crossed_fingers: 