### PR TITLE
show dataset downloads on metrics dashboard

### DIFF
--- a/ckanext/unhcr/blueprint.py
+++ b/ckanext/unhcr/blueprint.py
@@ -5,6 +5,7 @@ import ckan.plugins.toolkit as toolkit
 from .helpers import user_is_curator
 from .metrics import (
     get_datasets_by_date,
+    get_datasets_by_downloads,
     get_containers,
     get_containers_by_date,
     get_tags,
@@ -20,6 +21,7 @@ def metrics():
     return toolkit.render('metrics/index.html', {
         'metrics': [
             get_datasets_by_date(context),
+            get_datasets_by_downloads(context),
             get_containers(context),
             get_containers_by_date(context),
             get_tags(context),

--- a/ckanext/unhcr/blueprint.py
+++ b/ckanext/unhcr/blueprint.py
@@ -10,6 +10,7 @@ from .metrics import (
     get_containers_by_date,
     get_tags,
     get_users,
+    get_users_by_downloads,
 )
 
 def metrics():
@@ -22,10 +23,11 @@ def metrics():
         'metrics': [
             get_datasets_by_date(context),
             get_datasets_by_downloads(context),
-            get_containers(context),
             get_containers_by_date(context),
+            get_containers(context),
             get_tags(context),
             get_users(context),
+            get_users_by_downloads(context),
         ]
     })
 

--- a/ckanext/unhcr/metrics.py
+++ b/ckanext/unhcr/metrics.py
@@ -129,7 +129,7 @@ def get_containers_by_date(context):
         'type': 'timeseries_graph',
         'short_title': 'Containers',
         'title': title,
-        'total': dates.values()[-1],
+        'total': dates.values()[-1] if len(dates.values()) > 0 else None,
         'id': slugify(title),
         'data': [
             ['x'] + [str(date) for date in dates.keys()],


### PR DESCRIPTION
refs #269

This PR builds on #280 and uses the `'download resource'` activities to show some extra tables on the dashboard