### PR TITLE
fix auth check on /metrics

### DIFF
--- a/ckanext/unhcr/blueprint.py
+++ b/ckanext/unhcr/blueprint.py
@@ -14,10 +14,14 @@ from .metrics import (
 )
 
 def metrics():
-    context = { 'user': toolkit.c.user }
+    if (
+        not hasattr(toolkit.c, "user") or
+        not toolkit.c.user or
+        not (toolkit.c.userobj.sysadmin or user_is_curator())
+    ):
+        return toolkit.abort(403, "Forbidden")
 
-    if not (toolkit.c.userobj.sysadmin or user_is_curator()):
-        return toolkit.abort(403, 'Forbidden')
+    context = { 'user': toolkit.c.user }
 
     return toolkit.render('metrics/index.html', {
         'metrics': [

--- a/ckanext/unhcr/tests/test_controllers.py
+++ b/ckanext/unhcr/tests/test_controllers.py
@@ -1188,6 +1188,9 @@ class TestMetricsController(base.FunctionalTestBase):
 
     # Tests
 
+    def test_metrics_not_logged_in(self):
+        resp = self.get_request('/metrics', status=403)
+
     def test_metrics_standard_user(self):
         user1 = core_factories.User(name='user1', id='user1')
         resp = self.get_request('/metrics', user='user1', status=403)


### PR DESCRIPTION
unauthenticated request to `/metrics` will now show login prompt, not throw a 500 error