### PR TITLE
log 'download resource' activity with dataset_id not resource_id

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -256,6 +256,7 @@ def package_activity_list(context, data_dict):
     get_curation_activities = toolkit.asbool(
         data_dict.get('get_curation_activities'))
     full_list = get_core.package_activity_list(context, data_dict)
+    full_list = [a for a in full_list if a["activity_type"] != "download resource"]
     curation_activities = [
         a for a in full_list if 'curation_activity' in a.get('data', {})]
     normal_activities = [

--- a/ckanext/unhcr/activity.py
+++ b/ckanext/unhcr/activity.py
@@ -11,11 +11,13 @@ def log_download_activity(context, resource_id):
     if user_by_name is not None:
         user_id = user_by_name.id
 
+    resource = toolkit.get_action('resource_show')(context, {'id': resource_id})
+
     activity_dict = {
         'activity_type': 'download resource',
         'user_id': user_id,
-        'object_id': resource_id,
-        'data': {}
+        'object_id': resource['package_id'],
+        'data': resource
     }
 
     activity_create_context = {

--- a/ckanext/unhcr/metrics.py
+++ b/ckanext/unhcr/metrics.py
@@ -58,12 +58,9 @@ def get_datasets_by_date(context):
 
 def get_datasets_by_downloads(context):
     activity_table = model.meta.metadata.tables['activity']
-    resource_table = model.meta.metadata.tables['resource']
     package_table = model.meta.metadata.tables['package']
     join_obj = activity_table.join(
-        resource_table, resource_table.c.id==activity_table.c.object_id
-    ).join(
-        package_table, package_table.c.id==resource_table.c.package_id
+        package_table, package_table.c.id==activity_table.c.object_id
     )
 
     sql = select([
@@ -225,13 +222,10 @@ def get_users_by_datasets(context):
 
 def get_users_by_downloads(context):
     activity_table = model.meta.metadata.tables['activity']
-    resource_table = model.meta.metadata.tables['resource']
     package_table = model.meta.metadata.tables['package']
     user_table = model.meta.metadata.tables['user']
     join_obj = activity_table.join(
-        resource_table, resource_table.c.id==activity_table.c.object_id
-    ).join(
-        package_table, package_table.c.id==resource_table.c.package_id
+        package_table, package_table.c.id==activity_table.c.object_id
     ).join(
         user_table, user_table.c.id==activity_table.c.user_id
     )

--- a/ckanext/unhcr/tests/test_controllers.py
+++ b/ckanext/unhcr/tests/test_controllers.py
@@ -1052,7 +1052,7 @@ class TestExtendedPackageController(base.FunctionalTestBase):
         ]).where(
             and_(
                 model.Activity.activity_type == 'download resource',
-                model.Activity.object_id == self.resource1['id'],
+                model.Activity.object_id == self.dataset1['id'],
                 model.Activity.user_id == 'user1',
             )
         )

--- a/ckanext/unhcr/validators.py
+++ b/ckanext/unhcr/validators.py
@@ -189,7 +189,7 @@ def upload_not_empty(key, data, errors, context):
 # Custom Activities
 
 _object_id_validators = {
-    'download resource': validators.resource_id_exists,
+    'download resource': validators.package_id_exists,
 }
 
 def object_id_validator(key, activity_dict, errors, context):


### PR DESCRIPTION
refs #284

As discussed in https://github.com/okfn/ckanext-unhcr/issues/284#issuecomment-626718358 this switches us to logging the 'download resource' activity against the `dataset_id` instead of the `resource_id` so it is easier to query.

The downside of this is that we've already logged a bunch of download resource' activities in UAT against `resource_id`s and all that data will essentially become 'orphaned'. I haven't included any data migration in this PR to fix or delete those records. I think this is probably fine to just lose that data as that code is only deployed in UAT, but let me know if I need to do something else there.