### PR TITLE
run tests on postgres 11 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
-dist: trusty
+dist: xenial
 
 language: python
 python:
     - "2.7"
 addons:
-    postgresql: '9.6'
+    postgresql: '11'
+    apt:
+        packages:
+            - postgresql-11
+            - postgresql-client-11
 env:
-    - CKANVERSION=2.8
+    global:
+        - PGPORT=5433
+        - CKANVERSION=2.8
 install:
     - bash bin/travis-build.bash
 services:
-    - postgresql
     - redis
 script: sh bin/travis-run.sh
 after_success: coveralls

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -40,9 +40,9 @@ sudo -u postgres psql -c 'CREATE DATABASE datastore_test WITH OWNER ckan_default
 echo "Setting up Solr..."
 # Solr is multicore for tests on ckan master, but it's easier to run tests on
 # Travis single-core. See https://github.com/ckan/ckan/issues/2972
-printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty8
 sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
-sudo service jetty restart
+sudo service jetty8 restart
 sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
 
 echo "Initialising the database..."


### PR DESCRIPTION
As noted in https://github.com/okfn/ckanext-unhcr/pull/295#discussion_r424336800 now we're fully moved over to AWS, we should to bring our test environment into line with that configuration.
