### PR TITLE
Fix race condition when saving resource using cloudstorage engine

### DIFF
--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -335,7 +335,8 @@ class UnhcrPlugin(
 
     def after_create(self, context, data_dict):
         if not context.get('job'):
-            toolkit.enqueue_job(jobs.process_dataset_on_create, [data_dict['id']])
+            if data_dict.get('state') == 'active':
+                toolkit.enqueue_job(jobs.process_dataset_on_create, [data_dict['id']])
 
         if data_dict.get('type') == 'deposited-dataset':
             user_id = None
@@ -355,7 +356,8 @@ class UnhcrPlugin(
 
     def after_update(self, context, data_dict):
         if not context.get('job'):
-            toolkit.enqueue_job(jobs.process_dataset_on_update, [data_dict['id']])
+            if data_dict.get('state') == 'active':
+                toolkit.enqueue_job(jobs.process_dataset_on_update, [data_dict['id']])
 
     # IAuthFunctions
 


### PR DESCRIPTION
Closes #302

This explanantion is mostly just copy+pasted from Slack, but its worth preserving so it is available to refer to in future.

When we are using the cloudstorage backend, a resource upload is a multipart upload. Creating a resource and uploading a file makes multiple API calls - we call:
- `resource_create`
- `initiate_multipart`
- `upload_multipart` (N times)
- `finish_multipart`
Then at the end of the finish_multipart action, we call:

```py
toolkit.get_action('package_patch')(
    dict(context.copy(), allow_state_change=True),
    dict(id=pkg_dict['id'], state='active')
)
```
to update the package state to active.


There are serveral points in this process where we call CKAN's `after_update` hook, which runs our `after_update` function: https://github.com/okfn/ckanext-unhcr/blob/8a1ea4d398de5f77222acad930264b8c8f69c55d/ckanext/unhcr/plugin.py#L356 The first one of these is in `resource_create` while the `state` value is still `draft`. The last one kicks off when we set it to `active`. That `after_update` function queues a background job ( `process_dataset_on_update` ) in parallel which waits 3 seconds https://github.com/okfn/ckanext-unhcr/blob/8a1ea4d398de5f77222acad930264b8c8f69c55d/ckanext/unhcr/jobs.py#L38-L39 does a bunch of stuff, and then at some point later runs a `package_update`: https://github.com/okfn/ckanext-unhcr/blob/8a1ea4d398de5f77222acad930264b8c8f69c55d/ckanext/unhcr/jobs.py#L68

There is a (fairly common) condition where the first `after_update` hook completes after we perform the `package_patch` to set `state` to `active`, that sets the `state` back to `draft` again based on a stale package object which was fetched before we set `state` to `active` in `finish_multipart`, and then the last hook call grabs its package object some time after that.

This PR gives us a workaround by only adding the `process_dataset_on_update` job to the queue if the package state is `active`. In this scenario, that means only the last call to `after_update` (which fires when we run `toolkit.get_action('package_patch')(...state='active')` ) actually queues a job. The tradeoff is that the fields calculated in `process_dataset_on_update` won't be available on draft datasets.

