### PR TITLE
simplify datastore api auth code (to fix datapusher job)

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -415,29 +415,6 @@ def recently_changed_packages_activity_list_html(context, data_dict):
 
 # Datastore
 
-# We ended up with double auth checks for every action
-# because auth_audit requires calling non-unhcr auth functions too
-
-@toolkit.chained_action
-def datastore_info(action, context, data_dict):
-    toolkit.check_access('unhcr_datastore_info', context, data_dict)
-    return action(context, data_dict)
-
-
-@toolkit.chained_action
-#  @toolkit.side_effect_free
-def datastore_search(action, context, data_dict):
-    toolkit.check_access('unhcr_datastore_search', context, data_dict)
-    return action(context, data_dict)
-
-
-@toolkit.chained_action
-#  @toolkit.side_effect_free
-def datastore_search_sql(action, context, data_dict):
-    toolkit.check_access('unhcr_datastore_search_sql', context, data_dict)
-    return action(context, data_dict)
-
-
 @toolkit.side_effect_free
 def datasets_validation_report(context, data_dict):
 

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -225,17 +225,14 @@ def resource_download(context, data_dict):
     return {'success': False}
 
 
-@toolkit.auth_allow_anonymous_access
 def unhcr_datastore_info(context, data_dict):
     return auth_datastore_core.datastore_auth(context, data_dict, 'resource_download')
 
 
-@toolkit.auth_allow_anonymous_access
 def unhcr_datastore_search(context, data_dict):
     return auth_datastore_core.datastore_auth(context, data_dict, 'resource_download')
 
 
-@toolkit.auth_allow_anonymous_access
 def unhcr_datastore_search_sql(context, data_dict):
     '''need access to view all tables in query'''
 

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -391,9 +391,6 @@ class UnhcrPlugin(
             'group_activity_list_html': actions.group_activity_list_html,
             'organization_activity_list_html': actions.organization_activity_list_html,
             'recently_changed_packages_activity_list_html': actions.recently_changed_packages_activity_list_html,
-            'datastore_info': actions.datastore_info,
-            'datastore_search': actions.datastore_search,
-            'datastore_search_sql': actions.datastore_search_sql,
             'datasets_validation_report': actions.datasets_validation_report,
         }
 


### PR DESCRIPTION
refs #304

Again, this is mostly just stuff I've already said in Slack or on a call, but I'll re-state it here for future reference:

* In the datapusher code we make a call to our CKAN instance's API which passes some params in the query string: https://github.com/ckan/datapusher/blob/817ac25fbfbb2dd0a5cbe9de18cf602c99ed8f97/datapusher/jobs.py#L215-L222
* When CKAN core processes an API call, it requires the action to be `side_effect_free` to accept the API params in the query string: https://github.com/ckan/ckan/blob/7900935de6270ee80ec64a5378251dafedf3a0e4/ckan/views/api.py#L263-L266 (essentially, we shouldn't mutate state via `GET`)
* Our `datastore_search` isn't tagged as `side_effect_free` and uncommenting https://github.com/okfn/ckanext-unhcr/blob/d04287154acc73c23e88a64839a598bcf8c05110/ckanext/unhcr/actions.py#L428 doesn't fix that
* This causes the API call to `datastore_search` to fail, which in turn means the datapusher can't push to the datastore

I still haven't really got to the bottom of why the `side_effect_free` decorator isn't working as expected here. I think there is some odd interaction when using `side_effect_free` on a `chained_action`. However...

* It seems like the point of the `datastore_*` action functions is to run our custom auth function, but this is acheived by registering them in `IAuthFunctions` anyway. https://github.com/okfn/ckanext-unhcr/blob/d04287154acc73c23e88a64839a598bcf8c05110/ckanext/unhcr/plugin.py#L365-L367
* There doesn't seem to be any good reason for `auth_allow_anonymous_access` given everything in RIDL requires authentication and we pass the datapusher job a token when we register a job.

I think we can just remove all of this.
This also has the useful effect that if we do this, we're now using the default actions from CKAN core, `datastore_search` etc are marked `side_effect_free` and the datapusher works as expected.

Although I've manually tested the API, I haven't added any unit tests in this PR. There are some disabled tests in
https://github.com/okfn/ckanext-unhcr/blob/d04287154acc73c23e88a64839a598bcf8c05110/ckanext/unhcr/tests/test_actions.py#L299-L336
which should help us here, but after spending a small amount of time trying to fix them I think I'm going to end up disappearing down another fairly deep rabbit hole there. In the interests of staying focussed and moving the AWS project forward, I'm going to suggest I leave them as they are but raise an issue to get them working another day.

I'm reasonably sure this makes sense, but please do sanity check as I do lack a certain amount of context on this one.