### PR TITLE
fix labels on 'add member' form

### DIFF
--- a/ckanext/unhcr/templates/organization/member_new.html
+++ b/ckanext/unhcr/templates/organization/member_new.html
@@ -2,7 +2,7 @@
 {% set deposit = h.get_data_deposit() %}
 
 {% block form %}
-<form class="dataset-form form-horizontal add-member-form" method='post'>
+<form class="dataset-form add-member-form" method='post'>
   {# Username #}
   <div class="control-group control-medium">
     <label class="control-label" for="username">


### PR DESCRIPTION
closes #317

![Screenshot at 2020-06-08 11-26-40](https://user-images.githubusercontent.com/6025893/84020792-4f04af00-a97b-11ea-98c5-b54a22a44f42.png)

I think the widths are fine as they are. Its broadly the same as default CKAN (except we don't have the right panel for username)

![Screenshot at 2020-06-08 11-26-57](https://user-images.githubusercontent.com/6025893/84020835-680d6000-a97b-11ea-8a7b-0b8e5e434ef6.png)

If you want we can move the whole form content into a narrower container e.g:

![Screenshot at 2020-06-08 11-26-04](https://user-images.githubusercontent.com/6025893/84020875-7b203000-a97b-11ea-914c-721b82675b16.png)
