### PR TITLE
don't allow collaborators to be added to a deposited dataset

### DIFF
--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -60,6 +60,7 @@ def restrict_access_to_get_auth_functions():
     overriden_auth_functions['package_create'] = package_create
     overriden_auth_functions['package_update'] = package_update
     overriden_auth_functions['package_activity_list'] = package_activity_list
+    overriden_auth_functions['dataset_collaborator_create'] = dataset_collaborator_create
 
     return overriden_auth_functions
 
@@ -253,3 +254,12 @@ def unhcr_datastore_search_sql(context, data_dict):
 
 def datasets_validation_report(context, data_dict):
     return {'success': False}
+
+
+@toolkit.chained_auth_function
+def dataset_collaborator_create(next_auth, context, data_dict):
+    dataset = toolkit.get_action('package_show')(
+        {'ignore_auth': True}, {'id': data_dict['id']})
+    if dataset['type'] == 'deposited-dataset':
+        return {'success': False, 'msg': "Can't add collaborators to a Data Deposit"}
+    return next_auth(context, data_dict)

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -56,11 +56,7 @@ def restrict_access_to_get_auth_functions():
     overriden_auth_functions['site_read'] = site_read
     overriden_auth_functions['organization_list_for_user'] = \
         organization_list_for_user
-    overriden_auth_functions['organization_create'] = organization_create
-    overriden_auth_functions['package_create'] = package_create
-    overriden_auth_functions['package_update'] = package_update
     overriden_auth_functions['package_activity_list'] = package_activity_list
-    overriden_auth_functions['dataset_collaborator_create'] = dataset_collaborator_create
 
     return overriden_auth_functions
 

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -26,7 +26,7 @@ def restrict_access_to_get_auth_functions():
     skip_actions = [
         'help_show',  # Let's not overreact
         'site_read',  # Because of madness in the API controller
-        'organiation_list_for_user',  # Because of #4097
+        'organization_list_for_user',  # Because of #4097
         'get_site_user',
         'user_reset',  # saml2
         'user_create',  # saml2

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -366,6 +366,10 @@ class UnhcrPlugin(
         functions['unhcr_datastore_search'] = auth.unhcr_datastore_search
         functions['unhcr_datastore_search_sql'] = auth.unhcr_datastore_search_sql
         functions['datasets_validation_report'] = actions.datasets_validation_report
+        functions['organization_create'] = auth.organization_create
+        functions['package_create'] = auth.package_create
+        functions['package_update'] = auth.package_update
+        functions['dataset_collaborator_create'] = auth.dataset_collaborator_create
         return functions
 
     # IActions


### PR DESCRIPTION
closes #316 

Rather than doing this in the template code, I've done it at the auth level. This probably makes sense anyway and its what the template code uses to decide whether to show the tab or not:

https://github.com/okfn/ckanext-collaborators/blob/e48db4ad309a76f79e34fb1fbf16b0d20959dbea/ckanext/collaborators/templates/package/edit_base.html#L5