### PR TITLE
hard-code maintenance banner

### DIFF
--- a/ckanext/unhcr/templates/page.html
+++ b/ckanext/unhcr/templates/page.html
@@ -36,6 +36,9 @@
                   {% block flash %}
                     <div class="flash-messages">
                       {% block flash_inner %}
+                        <div class="alert fade in alert-info">
+                          RIDL will be offline for maintenance between midday and 2pm CEST on Thursday 18 June.
+                        </div>
                         {% for message in h.flash.pop_messages() | list %}
                           <div class="alert fade in {{ message.category }}">
                             {{ h.literal(message) }}


### PR DESCRIPTION
This hard-codes a notification at the top of any page which inherits from page.html aside from the login page.

I've made this a PR just so it gives me a place to put notes but I don't actually think we should merge it to master. We should just do an ad-hoc deploy using `pip install -e git+https://github.com/okfn/ckanext-unhcr.git@maintenance-banner#egg=ckanext-unhcr` in the Dockerfile.

We should confirm with the client that 10am to midday CEST is actually the window they want to block out for this.