### PR TITLE
menu styling improvements

### DIFF
--- a/ckanext/unhcr/fanstatic/theme.css
+++ b/ckanext/unhcr/fanstatic/theme.css
@@ -628,7 +628,7 @@ body {
   top: 22px;
 }
 
-@media (min-width: 992px) {
+@media (min-width: 768px) {
 
   .masthead .navbar-toggle,
   .masthead .navbar-toggle:hover,
@@ -684,6 +684,13 @@ body {
   content: "\f061";
 }
 
+@media (min-width: 992px) and (max-width: 1200px) {
+
+  .masthead .nav > li > a[href^="/"]::before {
+    content: none;
+  }
+}
+
 @media (min-width: 768px) {
 
   .masthead .nav > li > a {
@@ -705,6 +712,13 @@ body {
 
   .masthead .nav > li > a::before {
     font-size: 28px;
+  }
+}
+
+@media (min-width: 768px) {
+
+  .masthead .nav > li > a {
+    margin-bottom: 20px;
   }
 }
 

--- a/ckanext/unhcr/src/css/header.css
+++ b/ckanext/unhcr/src/css/header.css
@@ -152,7 +152,7 @@
     outline: none;
     top: 22px;
 
-    @media (--landscape-tablet-up) {
+    @media (--portrait-tablet-up) {
       display: none;
     }
   }
@@ -199,6 +199,14 @@
         }
       }
 
+      @media (--small-desktop) {
+        &[href^="/"] {
+          &::before {
+            content: none;
+          }
+        }
+      }
+
       @media (--portrait-tablet-up) {
         border: solid 1px #fff;
         margin-left: 20px;
@@ -215,6 +223,10 @@
         &::before {
           font-size: 28px;
         }
+      }
+
+      @media (--portrait-tablet-up) {
+        margin-bottom: 20px;
       }
     }
   }

--- a/ckanext/unhcr/src/css/vars.css
+++ b/ckanext/unhcr/src/css/vars.css
@@ -30,4 +30,5 @@
 @custom-media --phone-only (max-width: 767px);
 @custom-media --portrait-tablet-up (min-width: 768px);
 @custom-media --landscape-tablet-up (min-width: 992px);
+@custom-media --small-desktop (min-width: 992px) and (max-width: 1200px);
 @custom-media --desktop-up (min-width: 1200px);


### PR DESCRIPTION
A few small styling things going on in here:

1. Hide the "hamburger" menu icon in medium resolution layouts - it doesn't do anything useful (closes #301 )

2. Add a bit of space between the bottom of the menu and the end of the masthead in medium resolutions

before:

![Screenshot at 2020-06-16 17-51-17](https://user-images.githubusercontent.com/6025893/84804392-9bdf2a00-affa-11ea-8213-1152392aa2b4.png)

after:

![Screenshot at 2020-06-16 17-52-59](https://user-images.githubusercontent.com/6025893/84804405-a0a3de00-affa-11ea-9ba0-564eaabcb583.png)

3. Stop the menu spilling across 2 lines if there isn't enough room for all 4 items:

before:

![Screenshot at 2020-06-16 17-51-47](https://user-images.githubusercontent.com/6025893/84804547-dba61180-affa-11ea-9648-0e958147a81c.png)

after:

![Screenshot at 2020-06-16 17-52-39](https://user-images.githubusercontent.com/6025893/84804575-e52f7980-affa-11ea-9bb9-776888151b94.png)
