### PR TITLE
surface "download resource" activities in the front-end

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -256,11 +256,11 @@ def pending_requests_list(context, data_dict):
 
 @toolkit.side_effect_free
 def package_activity_list(context, data_dict):
-    get_curation_activities = toolkit.asbool(
-        data_dict.get('get_curation_activities'))
+    get_internal_activities = toolkit.asbool(
+        data_dict.get('get_internal_activities'))
     full_list = get_core.package_activity_list(context, data_dict)
     full_list = [a for a in full_list if a["activity_type"] != "download resource"]
-    curation_activities = [
+    internal_activities = [
         a for a in full_list if 'curation_activity' in a.get('data', {})]
     normal_activities = [
         a for a in full_list if 'curation_activity' not in a.get('data', {})]
@@ -271,8 +271,8 @@ def package_activity_list(context, data_dict):
             .get('data', {})
             .get('package_extra', {})
             .get('key') not in ('curation_state', 'curator_id'), normal_activities))
-    return (curation_activities
-        if get_curation_activities else normal_activities)
+    return (internal_activities
+        if get_internal_activities else normal_activities)
 
 
 @toolkit.side_effect_free

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -160,8 +160,8 @@ def package_update(next_auth, context, data_dict):
 
 
 def package_activity_list(context, data_dict):
-    if toolkit.asbool(data_dict.get('get_curation_activities')):
-        # Check if the user can see the curation activity,
+    if toolkit.asbool(data_dict.get('get_internal_activities')):
+        # Check if the user can see the internal activity,
         # for now we check if the user can edit the dataset
         return auth_update_core.package_update(context, data_dict)
     return {'success': True}

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -163,7 +163,11 @@ def package_activity_list(context, data_dict):
     if toolkit.asbool(data_dict.get('get_internal_activities')):
         # Check if the user can see the internal activity,
         # for now we check if the user can edit the dataset
-        return auth_update_core.package_update(context, data_dict)
+        try:
+            toolkit.check_access('package_update', context, data_dict)
+            return {'success': True}
+        except toolkit.NotAuthorized:
+            return {'success': False}
     return {'success': True}
 
 
@@ -197,8 +201,11 @@ def resource_download(context, data_dict):
         dataset.get('type') == 'deposited-dataset' and
         dataset.get('creator_user_id') == getattr(context.get('auth_user_obj'), 'id', None))
     if not user or is_depositor or not visibility or visibility != 'restricted':
-        return {
-            'success': toolkit.check_access('resource_show', context, data_dict)}
+        try:
+            toolkit.check_access('resource_show', context, data_dict)
+            return {'success': True}
+        except toolkit.NotAuthorized:
+            return {'success': False}
 
     # Restricted visibility (public metadata but private downloads)
     if dataset.get('owner_org'):

--- a/ckanext/unhcr/controllers/deposited_dataset.py
+++ b/ckanext/unhcr/controllers/deposited_dataset.py
@@ -332,33 +332,6 @@ class DepositedDatasetController(toolkit.BaseController):
         toolkit.h.flash_error(message % dataset['title'])
         toolkit.redirect_to('data-container_read', id='data-deposit')
 
-    # Activity
-
-    def activity(self, dataset_id):
-        '''Render package's curation activity stream page.'''
-
-        context = _get_context()
-        data_dict = {'id': dataset_id}
-        try:
-            # We check for package_show because
-            # in some states package_update can be forbidden
-            toolkit.check_access('package_show', context, data_dict)
-            toolkit.c.pkg_dict = toolkit.get_action('package_show')(context, data_dict)
-            toolkit.c.pkg = context['package']
-            toolkit.c.package_activity_stream = toolkit.get_action(
-                'package_activity_list_html')(
-                context, {
-                    'id': dataset_id,
-                    'get_curation_activities': True
-                })
-        except toolkit.ObjectNotFound:
-            toolkit.abort(404, toolkit._('Dataset not found'))
-        except toolkit.NotAuthorized:
-            toolkit.abort(403, toolkit._('Unauthorized to read the curation activity for dataset %s') % dataset_id)
-
-        return toolkit.render('package/activity.html', {'dataset_type': 'deposited-dataset'})
-
-
 
 # Internal
 

--- a/ckanext/unhcr/controllers/extended_package.py
+++ b/ckanext/unhcr/controllers/extended_package.py
@@ -126,6 +126,32 @@ class ExtendedPackageController(PackageController):
         log_download_activity(context, resource_id)
         return resp
 
+    # Activity
+
+    def activity(self, dataset_id):
+        '''Render package's internal activity stream page.'''
+
+        context = {'model': model, 'user': toolkit.c.user}
+        data_dict = {'id': dataset_id}
+        try:
+            # We check for package_show because
+            # in some states package_update can be forbidden
+            toolkit.check_access('package_show', context, data_dict)
+            toolkit.c.pkg_dict = toolkit.get_action('package_show')(context, data_dict)
+            toolkit.c.pkg = context['package']
+            toolkit.c.package_activity_stream = toolkit.get_action(
+                'package_activity_list_html')(
+                context, {
+                    'id': dataset_id,
+                    'get_internal_activities': True
+                })
+        except toolkit.ObjectNotFound:
+            toolkit.abort(404, toolkit._('Dataset not found'))
+        except toolkit.NotAuthorized:
+            toolkit.abort(403, toolkit._('Unauthorized to read the internal activity for dataset %s') % dataset_id)
+
+        return toolkit.render('package/activity.html', {'dataset_type': 'deposited-dataset'})
+
     # Publish
 
     def publish_microdata(self, id):

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -436,7 +436,7 @@ def get_user_deposited_drafts():
     return datasets
 
 
-# Curation activity
+# Internal activity
 
 def create_curation_activity(
         activity_type, dataset_id, dataset_name, user_id,
@@ -479,10 +479,10 @@ def custom_activity_renderer(context, activity):
         output =  toolkit._("{actor} submitted dataset {dataset} for curation")
     elif activity_name == 'curator_assigned':
         curator_link = core_helpers.tags.link_to(
-	    activity['data']['curator_name'],
+            activity['data']['curator_name'],
             toolkit.url_for(
                 controller='user', action='read', id=activity['data']['curator_name'])
-	)
+        )
         output =  toolkit._("{actor} assigned %s as Curator for dataset {dataset}" % curator_link)
     elif activity_name == 'curator_removed':
         output =  toolkit._("{actor} removed the assigned Curator from dataset {dataset}")

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -460,6 +460,16 @@ def create_curation_activity(
     toolkit.get_action('activity_create')(activity_context, data_dict)
 
 
+def download_resource_renderer(context, activity):
+    resource_name = activity['data']['name'] or 'Unnamed resource'
+    resource_link = toolkit.url_for(
+        action='resource_read',
+        controller='package',
+        id=activity['object_id'],
+        resource_id=activity['data']['id']
+    )
+    return "{actor} downloaded " + core_helpers.tags.link_to(resource_name, resource_link)
+
 def custom_activity_renderer(context, activity):
     '''
     Before CKAN 2.9 the only way to customize the activty stream snippets was to

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -10,7 +10,10 @@ from ckan.lib.plugins import DefaultTranslation
 from ckan.lib.plugins import DefaultPermissionLabels
 
 # 🙈
-from ckan.lib.activity_streams import activity_stream_string_functions
+from ckan.lib.activity_streams import (
+    activity_stream_string_functions,
+    activity_stream_string_icons,
+)
 
 from ckanext.unhcr import actions, auth, blueprint, helpers, jobs, validators
 
@@ -44,6 +47,8 @@ class UnhcrPlugin(
         toolkit.add_resource('fanstatic', 'unhcr')
 
         activity_stream_string_functions['changed package'] = helpers.custom_activity_renderer
+        activity_stream_string_functions['download resource'] = helpers.download_resource_renderer
+        activity_stream_string_icons['download resource'] = 'download'
 
     def update_config_schema(self, schema):
         schema.update({

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -376,6 +376,7 @@ class UnhcrPlugin(
         functions['unhcr_datastore_search_sql'] = auth.unhcr_datastore_search_sql
         functions['datasets_validation_report'] = auth.datasets_validation_report
         functions['organization_create'] = auth.organization_create
+        functions['package_activity_list'] = auth.package_activity_list
         functions['package_create'] = auth.package_create
         functions['package_update'] = auth.package_update
         functions['dataset_collaborator_create'] = auth.dataset_collaborator_create

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -80,8 +80,6 @@ class UnhcrPlugin(
         _map.connect('/deposited-dataset/{dataset_id}/reject', controller=controller, action='reject')
         _map.connect('/deposited-dataset/{dataset_id}/submit', controller=controller, action='submit')
         _map.connect('/deposited-dataset/{dataset_id}/withdraw', controller=controller, action='withdraw')
-        _map.connect('deposited-dataset_curation_activity', '/deposited-dataset/curation_activity/{dataset_id}', controller=controller, action='activity')
-        _map.connect('dataset_curation_activity','/dataset/curation_activity/{dataset_id}', controller=controller, action='activity')
 
         # package
 
@@ -114,6 +112,8 @@ class UnhcrPlugin(
         _map.connect('/dataset/{id}/resource_copy/{resource_id}', controller=controller, action='resource_copy')
         _map.connect('/dataset/{id}/publish_microdata', controller=controller, action='publish_microdata')
         _map.connect('/dataset/{id}/request_access', controller=controller, action='request_access', conditions={'method': ['POST']})
+        _map.connect('dataset_internal_activity', '/dataset/internal_activity/{dataset_id}', controller=controller, action='activity')
+        _map.connect('deposited-dataset_internal_activity', '/deposited-dataset/internal_activity/{dataset_id}', controller=controller, action='activity')
         if 'cloudstorage' not in config['ckan.plugins']:
             _map.connect('/dataset/{id}/resource/{resource_id}/download', controller=controller, action='resource_download')
             _map.connect('/dataset/{id}/resource/{resource_id}/download/{filename}', controller=controller, action='resource_download')

--- a/ckanext/unhcr/templates/package/read_base.html
+++ b/ckanext/unhcr/templates/package/read_base.html
@@ -9,12 +9,12 @@
 {% block content_primary_nav %}
   {% if pkg.type == 'deposited-dataset' %}
     {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
-  	{{ h.build_nav_icon('%s_curation_activity' % dataset_type, _('Curation Activity'), dataset_id=pkg.name, icon='gavel') }}
+  	{{ h.build_nav_icon('%s_internal_activity' % dataset_type, _('Internal Activity'), dataset_id=pkg.name, icon='gavel') }}
   {% else %}
     {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
     {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
     {% if h.check_access('package_update', {'user': c.user, 'id': c.pkg_dict.id}) %}
-      {{ h.build_nav_icon('%s_curation_activity' % dataset_type, _('Curation Activity'), dataset_id=pkg.name, icon='gavel') }}
+      {{ h.build_nav_icon('%s_internal_activity' % dataset_type, _('Internal Activity'), dataset_id=pkg.name, icon='gavel') }}
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -6,6 +6,7 @@ from ckan.tests import helpers as core_helpers, factories as core_factories
 from nose.tools import assert_raises, assert_equals, nottest
 from ckanext.unhcr.tests import base, factories, mocks
 from ckanext.unhcr import helpers
+from ckanext.unhcr.activity import log_download_activity
 
 
 class TestActions(base.FunctionalTestBase):
@@ -254,6 +255,102 @@ class TestPrivateResources(base.FunctionalTestBase):
         environ = {'REMOTE_USER': self.sysadmin['name'].encode('ascii')}
         res = app.get(url, extra_environ=environ)
         assert_equals(res.status_int, 200)
+
+
+class TestPackageActivityList(base.FunctionalTestBase):
+
+    def setup(self):
+        super(TestPackageActivityList, self).setup()
+
+        self.sysadmin = core_factories.Sysadmin(name='sysadmin', id='sysadmin')
+        self.container1_admin = core_factories.User()
+        self.container1_member = core_factories.User()
+        self.container1 = factories.DataContainer(
+            users=[
+                {"name": self.container1_admin["name"], "capacity": "admin"},
+                {"name": self.container1_member["name"], "capacity": "member"},
+            ]
+        )
+        self.dataset1 = factories.Dataset(
+            owner_org=self.container1["id"], visibility="private"
+        )
+        self.resource1 = factories.Resource(
+            package_id=self.dataset1['id'],
+            upload=mocks.FakeFileStorage(),
+            url = "http://fakeurl/test.txt",
+            url_type='upload',
+        )
+        helpers.create_curation_activity(
+            'dataset_approved',
+            self.dataset1['id'],
+            self.dataset1['name'],
+            self.sysadmin['id'],
+            message='asdf'
+        )
+        log_download_activity({'user': self.sysadmin['name']}, self.resource1['id'])
+
+    def test_container_admin(self):
+        context = {
+            'user': self.container1_admin['name'],
+            'package': model.package.Package.get(self.dataset1['id'])
+        }
+        data_dict = {
+            'id': self.dataset1['id'],
+            'get_internal_activities': True
+        }
+        activities = toolkit.get_action('package_activity_list')(context, data_dict)
+        # a container admin can see all the internal activities
+        assert_equals(2, len(activities))
+        assert_equals('download resource', activities[0]['activity_type'])
+        assert_equals('dataset_approved', activities[1]['data']['curation_activity'])
+
+    def test_dataset_editor(self):
+        collaborator = core_factories.User()
+        core_helpers.call_action(
+            'dataset_collaborator_create',
+            id=self.dataset1['id'],
+            user_id=collaborator['id'],
+            capacity='editor',
+        )
+        context = {
+            'user': collaborator['name'],
+            'package': model.package.Package.get(self.dataset1['id'])
+        }
+        data_dict = {
+            'id': self.dataset1['id'],
+            'get_internal_activities': True
+        }
+        activities = toolkit.get_action('package_activity_list')(context, data_dict)
+        # a dataset editor can only see the curation activities
+        assert_equals(1, len(activities))
+        assert_equals('dataset_approved', activities[0]['data']['curation_activity'])
+
+    def test_container_member(self):
+        context = {
+            'user': self.container1_member['name'],
+            'package': model.package.Package.get(self.dataset1['id'])
+        }
+        data_dict = {
+            'id': self.dataset1['id'],
+            'get_internal_activities': True
+        }
+        action = toolkit.get_action('package_activity_list')
+        # a container member can't see any internal activities
+        assert_raises(toolkit.NotAuthorized, action, context, data_dict)
+
+    def test_unprivileged_user(self):
+        normal_user = core_factories.User()
+        context = {
+            'user': normal_user['name'],
+            'package': model.package.Package.get(self.dataset1['id'])
+        }
+        data_dict = {
+            'id': self.dataset1['id'],
+            'get_internal_activities': True
+        }
+        action = toolkit.get_action('package_activity_list')
+        # an unprivileged user can't see any internal activities
+        assert_raises(toolkit.NotAuthorized, action, context, data_dict)
 
 
 class TestDatastoreAuthRestrictedDownloads(base.FunctionalTestBase):

--- a/ckanext/unhcr/tests/test_controllers.py
+++ b/ckanext/unhcr/tests/test_controllers.py
@@ -831,7 +831,7 @@ class TestDepositedDatasetController(base.FunctionalTestBase):
         env = {'REMOTE_USER': self.creator['name'].encode('ascii')}
         resp = self.app.get(
             url=url_for('deposited-dataset_read', id=self.dataset['id']), extra_environ=env)
-        assert_in('Curation Activity', resp.body)
+        assert_in('Internal Activity', resp.body)
 
     def test_activites_shown_on_normal_dataset(self):
         for user in ['sysadmin', 'editor']:
@@ -846,7 +846,7 @@ class TestDepositedDatasetController(base.FunctionalTestBase):
         resp = self.app.get(
             url=url_for('dataset_read', id=self.dataset['id']), extra_environ=env)
 
-        assert_in('Curation Activity', resp.body)
+        assert_in('Internal Activity', resp.body)
 
     def test_activites_not_shown_on_normal_dataset(self):
 
@@ -862,7 +862,7 @@ class TestDepositedDatasetController(base.FunctionalTestBase):
         resp = self.app.get(
             url=url_for('dataset_read', id=self.dataset['id']), extra_environ=env)
 
-        assert_not_in('Curation Activity', resp.body)
+        assert_not_in('Internal Activity', resp.body)
 
     @mock.patch('ckanext.unhcr.controllers.deposited_dataset.mailer.mail_user_by_id')
     def test_activity_created_in_deposited_dataset(self, mail):
@@ -874,7 +874,7 @@ class TestDepositedDatasetController(base.FunctionalTestBase):
 
         env = {'REMOTE_USER': self.curator['name'].encode('ascii')}
         resp = self.app.get(
-            url=url_for('deposited-dataset_curation_activity', dataset_id=self.dataset['name']), extra_environ=env)
+            url=url_for('deposited-dataset_internal_activity', dataset_id=self.dataset['name']), extra_environ=env)
 
         assert_in('deposited dataset', resp.body)
         assert_in('submitted dataset', resp.body)


### PR DESCRIPTION
This PR rebrands curation activities as "internal activities" and exposes resource download activities to container admins only, so:

- a container admin can see all the internal activities
- a dataset editor can only see the curation activities
- a container member can't see any internal activities
- an unprivileged user can't see any internal activities

Can you confirm that matches with your understanding of the feature requirements?

Closes #284