### PR TITLE
allow search results to be ordered by creation date

### DIFF
--- a/ckanext/unhcr/templates/package/search.html
+++ b/ckanext/unhcr/templates/package/search.html
@@ -1,0 +1,20 @@
+{% ckan_extends %}
+
+{% block form %}
+  {% set facets = {
+    'fields': fields_grouped,
+    'search': search_facets,
+    'titles': facet_titles,
+    'translated_fields': translated_fields,
+    'remove_field': remove_field }
+  %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_modified desc'),
+    (_('Name Ascending'), 'title_string asc'),
+    (_('Name Descending'), 'title_string desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Created'), 'metadata_created desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
+  {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+{% endblock %}


### PR DESCRIPTION
As far as I can tell there isn't a plugin interface we can use here - we just have to override the template.
It would be quite nice if there was a standard way for plugins to do this, like there is with facets.

closes #344