### PR TITLE
rebuild search index from admin

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -683,7 +683,6 @@ def search_index_rebuild(context, data_dict):
         .all()
     ]
     package_index = index_for(model.Package)
-    package_index.clear()
     errors = []
     context = {'model': model, 'ignore_auth': True, 'validate': False, 'use_cache': False}
     for pkg_id in package_ids:

--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -6,6 +6,8 @@ from ckan.authz import has_user_permission_for_group_or_org
 from ckan.plugins import toolkit
 from ckan.lib.mailer import MailerException
 import ckan.lib.plugins as lib_plugins
+from ckan.lib.search import index_for, commit
+import ckan.logic as core_logic
 import ckan.logic.action.get as get_core
 import ckan.logic.action.create as create_core
 import ckan.logic.action.delete as delete_core
@@ -642,7 +644,7 @@ def access_request_update(context, data_dict):
     }
 
 
-# User
+# Admin
 
 def user_update_sysadmin(context, data_dict):
     """
@@ -669,3 +671,32 @@ def user_update_sysadmin(context, data_dict):
     m.Session.refresh(user_obj)
 
     return model_dictize.user_dictize(user_obj, context)
+
+
+def search_index_rebuild(context, data_dict):
+    toolkit.check_access('search_index_rebuild', context, data_dict)
+
+    package_ids = [
+        r[0]
+        for r in model.Session.query(model.Package.id)
+        .filter(model.Package.state != "deleted")
+        .all()
+    ]
+    package_index = index_for(model.Package)
+    package_index.clear()
+    errors = []
+    context = {'model': model, 'ignore_auth': True, 'validate': False, 'use_cache': False}
+    for pkg_id in package_ids:
+        try:
+            package_index.update_dict(
+                core_logic.get_action('package_show')(context, {'id': pkg_id}),
+                defer_commit=True
+            )
+        except Exception as e:
+            errors.append('Encountered {error} processing {pkg}'.format(
+                error=repr(e),
+                pkg=pkg_id
+            ))
+
+    commit()
+    return errors

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -304,7 +304,11 @@ def access_request_update(context, data_dict):
     }
 
 
-# User
+# Admin
 
 def user_update_sysadmin(context, data_dict):
+    return {'success': False}
+
+
+def search_index_rebuild(context, data_dict):
     return {'success': False}

--- a/ckanext/unhcr/blueprints/__init__.py
+++ b/ckanext/unhcr/blueprints/__init__.py
@@ -3,4 +3,5 @@
 from .access_requests import unhcr_access_requests_blueprint
 from .admin import unhcr_admin_blueprint
 from .metrics import unhcr_metrics_blueprint
+from .search_index import unhcr_search_index_blueprint
 from .user import unhcr_user_blueprint

--- a/ckanext/unhcr/blueprints/search_index.py
+++ b/ckanext/unhcr/blueprints/search_index.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from flask import Blueprint
-import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins.toolkit as toolkit
-from ckan.lib.search import index_for, commit
 
 
 unhcr_search_index_blueprint = Blueprint(
@@ -31,33 +29,10 @@ def rebuild():
         return toolkit.abort(403, "Forbidden")
 
     try:
-        toolkit.check_access('sysadmin', {'user': toolkit.c.user})
+        errors = toolkit.get_action('search_index_rebuild')({'user': toolkit.c.user}, {})
     except toolkit.NotAuthorized:
         return toolkit.abort(403, 'Not authorized to rebuild search index')
 
-    package_ids = [
-        r[0]
-        for r in model.Session.query(model.Package.id)
-        .filter(model.Package.state != "deleted")
-        .all()
-    ]
-    package_index = index_for(model.Package)
-    package_index.clear()
-    errors = []
-    context = {'model': model, 'ignore_auth': True, 'validate': False, 'use_cache': False}
-    for pkg_id in package_ids:
-        try:
-            package_index.update_dict(
-                logic.get_action('package_show')(context, {'id': pkg_id}),
-                defer_commit=True
-            )
-        except Exception as e:
-            errors.append('Encountered {error} processing {pkg}'.format(
-                error=repr(e),
-                pkg=pkg_id
-            ))
-
-    commit()
     if errors:
         toolkit.h.flash_error('Search Index rebuild completed with errors')
         return toolkit.render('admin/search_index.html', { 'errors': "\n".join(errors) })

--- a/ckanext/unhcr/blueprints/search_index.py
+++ b/ckanext/unhcr/blueprints/search_index.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+from flask import Blueprint
+import ckan.logic as logic
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+from ckan.lib.search import index_for, commit
+
+
+unhcr_search_index_blueprint = Blueprint(
+    'unhcr_search_index',
+    __name__,
+    url_prefix=u'/ckan-admin/search_index'
+)
+
+
+def index():
+    if (not hasattr(toolkit.c, "user") or not toolkit.c.user):
+        return toolkit.abort(403, "Forbidden")
+
+    try:
+        toolkit.check_access('sysadmin', {'user': toolkit.c.user})
+    except toolkit.NotAuthorized:
+        return toolkit.abort(403, 'Not authorized to manage search index')
+
+    return toolkit.render('admin/search_index.html')
+
+
+def rebuild():
+    if (not hasattr(toolkit.c, "user") or not toolkit.c.user):
+        return toolkit.abort(403, "Forbidden")
+
+    try:
+        toolkit.check_access('sysadmin', {'user': toolkit.c.user})
+    except toolkit.NotAuthorized:
+        return toolkit.abort(403, 'Not authorized to rebuild search index')
+
+    package_ids = [
+        r[0]
+        for r in model.Session.query(model.Package.id)
+        .filter(model.Package.state != "deleted")
+        .all()
+    ]
+    package_index = index_for(model.Package)
+    package_index.clear()
+    errors = []
+    context = {'model': model, 'ignore_auth': True, 'validate': False, 'use_cache': False}
+    for pkg_id in package_ids:
+        try:
+            package_index.update_dict(
+                logic.get_action('package_show')(context, {'id': pkg_id}),
+                defer_commit=True
+            )
+        except Exception as e:
+            errors.append('Encountered {error} processing {pkg}'.format(
+                error=repr(e),
+                pkg=pkg_id
+            ))
+
+    commit()
+    if errors:
+        toolkit.h.flash_error('Search Index rebuild completed with errors')
+        return toolkit.render('admin/search_index.html', { 'errors': "\n".join(errors) })
+    else:
+        toolkit.h.flash_success('Search Index rebuild completed successfully')
+        return toolkit.redirect_to('unhcr_search_index.index')
+
+
+unhcr_search_index_blueprint.add_url_rule(
+    rule=u'/',
+    view_func=index,
+    methods=['GET',],
+    strict_slashes=False,
+)
+
+unhcr_search_index_blueprint.add_url_rule(
+    rule=u'/rebuild',
+    view_func=rebuild,
+    methods=['POST',],
+)

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -46,6 +46,10 @@ class UnhcrPlugin(
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'unhcr')
 
+        # TODO: in CKAN 2.9 we can add `icon='hdd-o'` here
+        # but not yet :(
+        toolkit.add_ckan_admin_tab(config_, 'unhcr_search_index.index', 'Cache')
+
         activity_stream_string_functions['changed package'] = helpers.custom_activity_renderer
         activity_stream_string_functions['download resource'] = helpers.download_resource_renderer
         activity_stream_string_icons['download resource'] = 'download'
@@ -479,5 +483,6 @@ class UnhcrPlugin(
             blueprints.unhcr_access_requests_blueprint,
             blueprints.unhcr_admin_blueprint,
             blueprints.unhcr_metrics_blueprint,
+            blueprints.unhcr_search_index_blueprint,
             blueprints.unhcr_user_blueprint,
         ]

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -388,6 +388,7 @@ class UnhcrPlugin(
         functions['access_request_list_for_user'] = auth.access_request_list_for_user
         functions['access_request_update'] = auth.access_request_update
         functions['user_update_sysadmin'] = auth.user_update_sysadmin
+        functions['search_index_rebuild'] = auth.search_index_rebuild
         return functions
 
     # IActions
@@ -417,6 +418,7 @@ class UnhcrPlugin(
             'recently_changed_packages_activity_list_html': actions.recently_changed_packages_activity_list_html,
             'datasets_validation_report': actions.datasets_validation_report,
             'user_update_sysadmin': actions.user_update_sysadmin,
+            'search_index_rebuild': actions.search_index_rebuild,
         }
 
     # IValidators

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -48,7 +48,7 @@ class UnhcrPlugin(
 
         # TODO: in CKAN 2.9 we can add `icon='hdd-o'` here
         # but not yet :(
-        toolkit.add_ckan_admin_tab(config_, 'unhcr_search_index.index', 'Cache')
+        toolkit.add_ckan_admin_tab(config_, 'unhcr_search_index.index', 'Search Index')
 
         activity_stream_string_functions['changed package'] = helpers.custom_activity_renderer
         activity_stream_string_functions['download resource'] = helpers.download_resource_renderer

--- a/ckanext/unhcr/templates/admin/search_index.html
+++ b/ckanext/unhcr/templates/admin/search_index.html
@@ -1,0 +1,32 @@
+{% extends "admin/base.html" %}
+
+{% block primary_content_inner %}
+  {% if errors: %}
+    <pre>{{ errors }}</pre>
+  {% endif %}
+
+  <form method="POST" id="form-rebuild-index" action="{{ h.url_for('unhcr_search_index.rebuild') }}">
+    <button
+      type="submit"
+      name="rebuild-index"
+      value="rebuild"
+      class="btn btn-danger"
+    >
+      {% trans %}Rebuild Index{% endtrans %}
+    </button>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  <div class="module module-narrow module-shallow">
+    <h2 class="module-heading">
+      <i class="fa fa-info-circle"></i>
+      {{ _('Search Index') }}
+    </h2>
+    <div class="module-content">
+      {% trans %}
+        <p>Manage the Solr index for this instance.</p>
+      {% endtrans %}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
I guess we could really go wild on this one and implement the kitchen-sink of commands and flags under `paster --plugin=ckan search-index` here, but I've just added a single button for a full cache rebuild.

closes #349
