### PR TITLE
add a banner to UAT

### DIFF
--- a/ckanext/unhcr/fanstatic/theme.css
+++ b/ckanext/unhcr/fanstatic/theme.css
@@ -1442,6 +1442,24 @@ ol.unstyled {
   color: #fff;
 }
 
+.env-banner {
+  position: fixed;
+  z-index: 2;
+  width: 100%;
+  left: 0;
+  top: 100px;
+  height: 1.3em;
+  background-color: rgb(51, 51, 51);
+  color: #fff;
+  text-align: center;
+}
+
+@media (min-width: 992px) {
+  .env-banner {
+    top: 0px;
+  }
+}
+
 .site-footer {
   background-color: #000;
   color: rgba(255,255,255, 0.8);

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from urllib import quote
 from jinja2 import Markup, escape
@@ -747,6 +748,13 @@ def get_sysadmins():
 
 def get_ridl_version():
     return __VERSION__
+
+
+def get_envname():
+    envname = os.environ.get('ENV_NAME')
+    if not envname:
+        return 'dev'
+    return envname.lower()
 
 
 _paragraph_re = re.compile(r'(?:\r\n|\r(?!\n)|\n){2,}')

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -211,6 +211,7 @@ class UnhcrPlugin(
             'can_download': helpers.can_download,
             'get_choice_label': helpers.get_choice_label,
             'get_ridl_version': helpers.get_ridl_version,
+            'get_envname': helpers.get_envname,
             'nl_to_br': helpers.nl_to_br,
         }
 

--- a/ckanext/unhcr/src/css/flash-messages.css
+++ b/ckanext/unhcr/src/css/flash-messages.css
@@ -38,3 +38,21 @@
     }
   }
 }
+
+.env-banner {
+  position: fixed;
+  z-index: 2;
+  width: 100%;
+  left: 0;
+  top: 100px;
+  height: 1.3em;
+  background-color: rgb(51, 51, 51);
+  color: #fff;
+  text-align: center;
+}
+
+@media (--landscape-tablet-up) {
+  .env-banner {
+    top: 0px;
+  }
+}

--- a/ckanext/unhcr/templates/page.html
+++ b/ckanext/unhcr/templates/page.html
@@ -10,6 +10,11 @@
 
 
 {% block page %}
+{% if h.get_envname() not in ('prod', 'dev') %}
+<div class="env-banner">
+  This is a {{ h.get_envname()|upper }} site: {{ g.site_url }}
+</div>
+{% endif %}
 <div class="page">
   {% if not h.page_authorized() %}
     {% snippet "login_form.html" %}


### PR DESCRIPTION
Refs https://github.com/okfn/docker-ckan-unhcr-aws/pull/8
Closes #360

#360 is a useful idea. I have more than once been confused about this and its something I do usually do for test/staging sites etc. We probably should have thought of it already. I've tried to strike a decent balance here between the banner being obvious enough to be useful at a glance and subtle enough that its not annoying if its permanently on every page in UAT.
