### PR TITLE
handle ObjectNotFound cleanly in resource_download

### DIFF
--- a/ckanext/unhcr/controllers/extended_package.py
+++ b/ckanext/unhcr/controllers/extended_package.py
@@ -107,7 +107,7 @@ class ExtendedPackageController(PackageController):
     def resource_download(self, id, resource_id, filename=None):
         """
         Wraps default `resource_download` endpoint checking
-        the custom `resoruce_download` auth function
+        the custom `resource_download` auth function
         """
         context = {'model': model, 'session': model.Session,
                    'user': toolkit.c.user, 'auth_user_obj': toolkit.c.userobj}
@@ -115,6 +115,7 @@ class ExtendedPackageController(PackageController):
         # Check resource_download access
         try:
             toolkit.check_access(u'resource_download', context, {u'id': resource_id})
+            toolkit.get_action('resource_show')(context, {u'id': resource_id})
         except toolkit.ObjectNotFound:
             return toolkit.abort(404, toolkit._(u'Resource not found'))
         except toolkit.NotAuthorized:

--- a/ckanext/unhcr/controllers/extended_storage.py
+++ b/ckanext/unhcr/controllers/extended_storage.py
@@ -17,6 +17,7 @@ class ExtendedStorageController(StorageController):
         # Check resource_download access
         try:
             toolkit.check_access(u'resource_download', context, {u'id': resource_id})
+            toolkit.get_action('resource_show')(context, {u'id': resource_id})
         except toolkit.ObjectNotFound:
             return toolkit.abort(404, toolkit._(u'Resource not found'))
         except toolkit.NotAuthorized:


### PR DESCRIPTION
While I was testing something else, I noticed that we're not handling the 404 case properly because `auth.resource_download` doesn't actually throw a `ObjectNotFound` if the resource doesn't exist.

I've done this for now, but I wonder if I should either:

- Call `get_action('resource_show')` inside `auth.resource_download` (is it convention in CKAN that auth functions should always throw a `ObjectNotFound` if the thing we're checking auth against doesn't exist?)
- Just check the auth/403 case here and move the `ObjectNotFound` check to later in the function when we actually try to do something with the resource (which will make one less query in the success case)

