### PR TITLE
explain draft datasets in the sidebar

### DIFF
--- a/ckanext/unhcr/templates/package/new_resource.html
+++ b/ckanext/unhcr/templates/package/new_resource.html
@@ -1,0 +1,33 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+  {% snippet 'package/snippets/resource_help.html' %}
+  <section class="module module-narrow module-shallow">
+    <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('Draft Dataset') }}</h2>
+    <div class="module-content">
+      <p>
+        This dataset is saved as a <strong>draft</strong>. You can
+        <strong>
+        {{
+          h.link_to(
+            'edit or publish it',
+            h.url_for(controller='package', action='edit', id=pkg_name)
+          )
+        }}
+        </strong>
+        later.
+      </p>
+      <p>
+        All your Draft datasets are listed at
+        <strong>
+        {{
+          h.link_to(
+            'My Datasets',
+            h.url_for(controller='user', action='read', id=c.user)
+          )
+        }}
+        </strong>
+      </p>
+    </div>
+  </section>
+{% endblock %}


### PR DESCRIPTION
closes #357 

The issue here was that users click "Save and Add Another" instead of "Finish" and then don't know how to publish the dataset without adding more files.
This adds some help to the sidebar on the add resource page (which is where they'll end up).
Note this will only be shown when the dataset is draft because [new_resource](https://github.com/ckan/ckan/blob/ckan-2.8.4/ckan/templates/package/new_resource.html) and  [new_resource_not_draft](https://github.com/ckan/ckan/blob/ckan-2.8.4/ckan/templates/package/new_resource_not_draft.html) are two different templates. We don't need to explicitly check for it.

I did have a look to see if we could link direct to `/dataset/publish/{id}`on this page if the dataset already has >1 data resources attached to it. Unfortunately in `new_resource` we don't have the necessary vars in the template scope. I reckon linking to publish even when there are zero resources probably creates more confusion. This is broadly in line with the suggested improvement anyway.