### PR TITLE
Add external users

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,15 +178,15 @@ Create users using command line interface:
 
 ```
 # Sysadmin
-docker-compose -f ../../docker-compose.dev.yml exec ckan-dev paster --plugin=ckan sysadmin add ckan_sysadmin email=sysadmin@example.com password=testpass -c /srv/app/production.ini
+docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan sysadmin add ckan_sysadmin email=sysadmin@example.com password=testpass -c /srv/app/production.ini
 # Depadmin
-docker-compose -f ../../docker-compose.dev.yml exec ckan-dev paster --plugin=ckan user add ckan_depadmin email=depadmin@example.com password=testpass -c /srv/app/production.ini
+docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_depadmin email=depadmin@example.com password=testpass -c /srv/app/production.ini
 # Curators
-docker-compose -f ../../docker-compose.dev.yml exec ckan-dev paster --plugin=ckan user add ckan_curator1 email=curator1@example.com password=testpass -c /srv/app/production.ini
-docker-compose -f ../../docker-compose.dev.yml exec ckan-dev paster --plugin=ckan user add ckan_curator2 email=curator2@example.com password=testpass -c /srv/app/production.ini
+docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_curator1 email=curator1@example.com password=testpass -c /srv/app/production.ini
+docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_curator2 email=curator2@example.com password=testpass -c /srv/app/production.ini
 # Depositors
-docker-compose -f ../../docker-compose.dev.yml exec ckan-dev paster --plugin=ckan user add ckan_user1 email=user1@example.com password=testpass -c /srv/app/production.ini
-docker-compose -f ../../docker-compose.dev.yml exec ckan-dev paster --plugin=ckan user add ckan_user2 email=user2@example.com password=testpass -c /srv/app/production.ini
+docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_user1 email=user1@example.com password=testpass -c /srv/app/production.ini
+docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_user2 email=user2@example.com password=testpass -c /srv/app/production.ini
 ```
 
 Add admins and and editors to data deposit using web interface:

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan us
 # Depositors
 docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_user1 email=user1@example.com password=testpass -c /srv/app/production.ini
 docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_user2 email=user2@example.com password=testpass -c /srv/app/production.ini
+docker-compose -f ../../docker-compose.yml exec ckan-dev paster --plugin=ckan user add ckan_external email=user@outsider.example.com password=testpass -c /srv/app/production.ini
 ```
 
 Add admins and and editors to data deposit using web interface:

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -8,6 +8,7 @@ import ckanext.datastore.logic.auth as auth_datastore_core
 from ckan.logic.auth import get as core_get, get_resource_object
 from ckanext.unhcr import helpers
 from ckanext.unhcr.models import AccessRequest
+from ckanext.unhcr.utils import get_module_functions
 log = logging.getLogger(__name__)
 
 
@@ -24,7 +25,7 @@ def restrict_access_to_get_auth_functions():
     False).
     '''
 
-    core_auth_functions = {}
+    core_auth_functions = get_module_functions('ckan.logic.auth.get')
     skip_actions = [
         'help_show',  # Let's not overreact
         'site_read',  # Because of madness in the API controller
@@ -35,17 +36,7 @@ def restrict_access_to_get_auth_functions():
         'user_delete',  # saml2
         'request_reset',  # saml2
     ]
-    module_path = 'ckan.logic.auth.get'
-    module = __import__(module_path)
 
-    for part in module_path.split('.')[1:]:
-        module = getattr(module, part)
-
-    for key, value in module.__dict__.items():
-        if not key.startswith('_') and (
-            hasattr(value, '__call__')
-                and (value.__module__ == module_path)):
-            core_auth_functions[key] = value
     overriden_auth_functions = {}
     for key, value in core_auth_functions.items():
 

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -21,6 +21,23 @@ from ckanext.unhcr.models import AccessRequest
 
 log = logging.getLogger(__name__)
 
+# Core overrides
+
+@core_helpers.core_helper
+def new_activities(*args, **kwargs):
+    try:
+        return core_helpers.new_activities(*args, **kwargs)
+    except toolkit.NotAuthorized:
+        return 0
+
+
+@core_helpers.core_helper
+def dashboard_activity_stream(*args, **kwargs):
+    try:
+        return core_helpers.dashboard_activity_stream(*args, **kwargs)
+    except toolkit.NotAuthorized:
+        return []
+
 
 # General
 
@@ -130,7 +147,7 @@ def user_is_curator():
     group = get_data_deposit()
     try:
         users = toolkit.get_action('member_list')(
-            { 'user': user },
+            { 'ignore_auth': True },
             { 'id': group['id'] }
         )
     except toolkit.ObjectNotFound:

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -527,6 +527,10 @@ class UnhcrPlugin(
         # For curating users
         # Adding "deposited-dataset" label for data curators
         if user_obj:
+
+            if user_obj.external:
+                return ['']
+
             context = {u'user': user_obj.id}
             deposit = helpers.get_data_deposit()
             orgs = toolkit.get_action('organization_list_for_user')(context, {})

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -240,6 +240,9 @@ class UnhcrPlugin(
 
     def get_helpers(self):
         return {
+            # Core overrides
+            'new_activities': helpers.new_activities,
+            'dashboard_activity_stream': helpers.dashboard_activity_stream,
             # General
             'get_data_container': helpers.get_data_container,
             'get_all_data_containers': helpers.get_all_data_containers,

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -4,12 +4,14 @@ import json
 import logging
 
 from ckan.common import config
+from ckan.model import User
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.lib.plugins import DefaultTranslation
 from ckan.lib.plugins import DefaultPermissionLabels
 
 # 🙈
+import ckan.authz as authz
 from ckan.lib.activity_streams import (
     activity_stream_string_functions,
     activity_stream_string_icons,
@@ -23,6 +25,53 @@ from ckanext.hierarchy.helpers import group_tree_section
 log = logging.getLogger(__name__)
 
 _ = toolkit._
+
+
+INTERNAL_DOMAINS = ['unhcr.org']
+
+
+def user_is_external(user):
+    '''
+    Returns True if user email is not in the managed internal domains.
+    '''
+    try:
+        domain = user.email.split('@')[1]
+    except AttributeError:
+         # Internal sysadmin user does not have email
+        if user.sysadmin:
+            return False
+        else:
+            return True
+
+    internal_domains = toolkit.aslist(
+        toolkit.config.get('ckanext.unhcr.internal_domains', INTERNAL_DOMAINS),
+        sep = ','
+    )
+
+    return domain not in internal_domains
+
+
+def restrict_external(func):
+    '''
+    Decorator function to restrict external users to a small number of allowed_actions
+    '''
+
+    allowed_actions = [
+        'package_search',
+    ]
+
+    def wrapper(action, context, data_dict=None):
+        user = User.by_name(context.get('user'))
+        if not user:
+            return func(action, context, data_dict)
+        if user.sysadmin:
+            return func(action, context, data_dict)
+        if context.get('ignore_auth'):
+            return func(action, context, data_dict)
+        if user.external and action not in allowed_actions:
+            return {'success': False, 'msg': 'Not allowed to perform this action'}
+        return func(action, context, data_dict)
+    return wrapper
 
 
 class UnhcrPlugin(
@@ -53,6 +102,9 @@ class UnhcrPlugin(
         activity_stream_string_functions['changed package'] = helpers.custom_activity_renderer
         activity_stream_string_functions['download resource'] = helpers.download_resource_renderer
         activity_stream_string_icons['download resource'] = 'download'
+
+        User.external = property(user_is_external)
+        authz.is_authorized = restrict_external(authz.is_authorized)
 
     def update_config_schema(self, schema):
         schema.update({

--- a/ckanext/unhcr/tests/base.py
+++ b/ckanext/unhcr/tests/base.py
@@ -1,6 +1,7 @@
 import pylons
 from ckan.lib.search import rebuild
 from paste.registry import Registry
+from ckan.plugins import toolkit
 from ckan.tests import helpers as core_helpers, factories as core_factories
 from ckanext.unhcr.models import create_tables as unhcr_create_tables
 from ckanext.collaborators.model import (

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -956,6 +956,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             {'id': self.dataset_request.id, 'status': 'invalid-status'}
         )
 
+
 class TestUpdateSysadmin(base.FunctionalTestBase):
 
     def test_sysadmin_not_authorized(self):
@@ -1012,3 +1013,18 @@ class TestUpdateSysadmin(base.FunctionalTestBase):
         # now they are not a sysadmin any more
         userobj = model.User.get(user['id'])
         assert_equals(False, userobj.sysadmin)
+
+
+class TestPackageSearch(base.FunctionalTestBase):
+
+    def test_package_search_permissions(self):
+        internal_user = core_factories.User()
+        external_user = core_factories.User(email='fred@externaluser.com')
+        dataset = factories.Dataset(private=True)
+        action = toolkit.get_action("package_search")
+
+        internal_user_search_result = action({'user': internal_user["name"]}, {})
+        external_user_search_result = action({'user': external_user["name"]}, {})
+
+        assert_equals(1, internal_user_search_result['count'])  # internal_user can see this
+        assert_equals(0, external_user_search_result['count'])  # external_user can't

--- a/ckanext/unhcr/tests/test_auth.py
+++ b/ckanext/unhcr/tests/test_auth.py
@@ -114,6 +114,46 @@ class TestAuthUI(base.FunctionalTestBase):
             response.body
         )
 
+    def test_external_users_endpoints(self):
+        app = self._get_test_app()
+
+        external_user = core_factories.User(email='fred@externaluser.com')
+        dataset = factories.Dataset()
+        container = factories.DataContainer()
+        env = {'REMOTE_USER': external_user['name'].encode('ascii')}
+
+        endpoints_403 = [
+            '/',
+            '/about',
+            '/ckan-admin',
+            '/dashboard',
+            '/metrics',
+            '/tag',
+            '/dataset',
+            '/data-container',
+            '/organization',
+            '/group',
+        ]
+        for endpoint in endpoints_403:
+            resp = app.get(endpoint, extra_environ=env, status=403)
+
+        endpoints_404 = [
+            '/dataset/{}'.format(dataset['name']),
+            '/data-container/data-deposit',
+            '/data-container/{}'.format(container['name']),
+            '/organization/{}'.format(container['name']),
+            '/group/{}'.format(container['name']),
+        ]
+        for endpoint in endpoints_404:
+            # these throw a 404 rather than a 403
+            resp = app.get(endpoint, extra_environ=env, status=404)
+
+        endpoints_200 = [
+            '/feeds/dataset.atom',
+        ]
+        for endpoint in endpoints_200:
+            resp = app.get(endpoint, extra_environ=env, status=200)
+
 
 class TestAuthAPI(base.FunctionalTestBase):
 

--- a/ckanext/unhcr/tests/test_auth.py
+++ b/ckanext/unhcr/tests/test_auth.py
@@ -9,26 +9,10 @@ from ckan.tests import helpers
 from ckan.tests import factories as core_factories
 
 from ckanext.unhcr import auth
-from ckanext.unhcr.tests import factories
+from ckanext.unhcr.tests import base, factories
 
 
-# TODO: extract as a test base for all tests
-class AuthTestBase(helpers.FunctionalTestBase):
-
-    @classmethod
-    def setup_class(cls):
-
-        # Hack because the hierarchy extension uses c in some methods
-        # that are called outside the context of a web request
-        c = pylons.util.AttribSafeContextObj()
-        registry = Registry()
-        registry.prepare()
-        registry.register(pylons.c, c)
-
-        super(AuthTestBase, cls).setup_class()
-
-
-class TestAuthUI(AuthTestBase):
+class TestAuthUI(base.FunctionalTestBase):
 
     def test_non_logged_in_users(self):
         app = self._get_test_app()
@@ -131,7 +115,7 @@ class TestAuthUI(AuthTestBase):
         )
 
 
-class TestAuthAPI(AuthTestBase):
+class TestAuthAPI(base.FunctionalTestBase):
 
     def test_non_logged_in_users(self):
 
@@ -212,7 +196,7 @@ class TestAuthAPI(AuthTestBase):
             'user_show', context=context, id=user['id'])
 
 
-class TestAuthUnit(AuthTestBase):
+class TestAuthUnit(base.FunctionalTestBase):
 
     # Package
 

--- a/ckanext/unhcr/tests/test_helpers.py
+++ b/ckanext/unhcr/tests/test_helpers.py
@@ -7,28 +7,14 @@ from paste.registry import Registry
 from nose.plugins.attrib import attr
 from ckan.tests import factories as core_factories
 from nose.tools import assert_raises, assert_equals
-from ckan.tests.helpers import call_action, FunctionalTestBase
+from ckan.tests.helpers import call_action
 from ckanext.unhcr.helpers import get_linked_datasets_for_form, get_linked_datasets_for_display
 from ckanext.unhcr.models import AccessRequest
-from ckanext.unhcr.tests import factories
+from ckanext.unhcr.tests import base, factories
 from ckanext.unhcr import helpers
 
 
-class TestHelpers(FunctionalTestBase):
-
-    # Setup
-
-    @classmethod
-    def setup_class(cls):
-
-        # Hack because the hierarchy extension uses c in some methods
-        # that are called outside the context of a web request
-        c = pylons.util.AttribSafeContextObj()
-        registry = Registry()
-        registry.prepare()
-        registry.register(pylons.c, c)
-
-        super(TestHelpers, cls).setup_class()
+class TestHelpers(base.FunctionalTestBase):
 
     # General
 

--- a/ckanext/unhcr/tests/test_plugin.py
+++ b/ckanext/unhcr/tests/test_plugin.py
@@ -6,15 +6,15 @@ from nose.plugins.attrib import attr
 
 from ckan import model
 import ckan.plugins.toolkit as toolkit
-from ckanext.unhcr.tests import factories
+from ckanext.unhcr.tests import base, factories
 from ckan.tests import factories as core_factories
 from nose.tools import assert_raises, assert_equals
-from ckan.tests.helpers import call_action, call_auth, FunctionalTestBase
+from ckan.tests.helpers import call_action, call_auth
 
 
 # Tests
 
-class TestRequestDataContainer(FunctionalTestBase):
+class TestRequestDataContainer(base.FunctionalTestBase):
 
     @classmethod
     def setup_class(cls):

--- a/ckanext/unhcr/tests/test_validators.py
+++ b/ckanext/unhcr/tests/test_validators.py
@@ -7,12 +7,12 @@ from nose.plugins.attrib import attr
 import ckan.lib.navl.dictization_functions as df
 from ckan.tests import factories as core_factories
 from nose.tools import assert_raises, assert_equals
-from ckan.tests.helpers import call_action, FunctionalTestBase
-from ckanext.unhcr.tests import factories
+from ckan.tests.helpers import call_action
+from ckanext.unhcr.tests import base, factories
 from ckanext.unhcr import validators
 
 
-class TestValidators(FunctionalTestBase):
+class TestValidators(base.FunctionalTestBase):
 
     # Config
 

--- a/ckanext/unhcr/utils.py
+++ b/ckanext/unhcr/utils.py
@@ -9,3 +9,18 @@ def normalize_list(value):
     if value:
         return value.split(',')
     return []
+
+
+def get_module_functions(module_path):
+    module_functions = {}
+    module = __import__(module_path)
+
+    for part in module_path.split('.')[1:]:
+        module = getattr(module, part)
+
+    for key, value in module.__dict__.items():
+        if not key.startswith('_') and (
+            hasattr(value, '__call__')
+                and (value.__module__ == module_path)):
+            module_functions[key] = value
+    return module_functions

--- a/test.ini
+++ b/test.ini
@@ -19,6 +19,7 @@ scheming.dataset_schemas=ckanext.unhcr.schemas:dataset.json ckanext.unhcr.schema
 scheming.presets=ckanext.scheming:presets.json ckanext.unhcr.schemas:presets.json
 scheming.organization_schemas=ckanext.unhcr.schemas:data_container.json
 scheming.organization_fallback=true
+ckanext.unhcr.internal_domains=unhcr.org,ckan.org
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Closes #371
Refs https://github.com/okfn/docker-ckan-unhcr-aws/pull/9

The main thing that's going on in this PR is I'm adding a new class of user: `external`. As an opening gambit, external users can log in, but then can't see or do anything. We can start to selectively enable certain actions as a next step.

One of the things I've thought about since we last spoke and hopefully achieved here is testing this functionality in a way that:

- Gives us confidence this works correctly
- Will flag problems if CKAN or plugins change under us
- Doesn't require us to explicitly add an additional `external_user` test case to every single action test

I'll mark up with some more comments inline.