### PR TITLE
Ensure external users aren't directed from /data-deposit to /dataset

### DIFF
--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -745,7 +745,7 @@ def current_path(action=None):
     path = toolkit.request.path
     if action == '/dataset/new':
         path = '/dataset/new'
-    if path.startswith('/dataset/copy'):
+    if path.startswith('/dataset/copy') or path.startswith('/deposited-dataset/copy'):
         path = '/dataset/new'
     return path
 

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -39,6 +39,11 @@ def dashboard_activity_stream(*args, **kwargs):
         return []
 
 
+@core_helpers.core_helper
+def url_for(*args, **kw):
+    return core_helpers.url_for(*args, **kw)
+
+
 # General
 
 def get_data_container(id, context=None):

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -187,13 +187,35 @@ class UnhcrPlugin(
         _map.connect('/dataset/{id}/request_access', controller=controller, action='request_access', conditions={'method': ['POST']})
         _map.connect('dataset_internal_activity', '/dataset/internal_activity/{dataset_id}', controller=controller, action='activity')
         _map.connect('deposited-dataset_internal_activity', '/deposited-dataset/internal_activity/{dataset_id}', controller=controller, action='activity')
+
+        # additional aliases to map /deposited-dataset/stuff routes
+        # these are needed because register_package_plugins() only maps a
+        # subset of /dataset routes for custom package types
+        _map.connect('/deposited-dataset/resources/{id}', controller=controller, action='resources')
+        _map.connect('/deposited-dataset/{id}/resource_copy/{resource_id}', controller=controller, action='resource_copy')
+        _map.connect('/deposited-dataset/{id}/resource_delete/{resource_id}', controller=controller, action='resource_delete')
+        _map.connect('/deposited-dataset/{id}/resource_edit/{resource_id}', controller=controller, action='resource_edit')
+        _map.connect('/deposited-dataset/{id}/resource/{resource_id}', controller=controller, action='resource_read')
+        _map.connect('/deposited-dataset/{id}/resource/{resource_id}/view/{view_id}', controller=controller, action='resource_view')
+        _map.connect('/deposited-dataset/activity/{dataset_id}', controller=controller, action='activity')
+        _map.connect('/deposited-dataset/activity/{dataset_id}/{offset}', controller=controller, action='activity')
+        _map.connect('/deposited-dataset/copy/{id}', controller=controller, action='copy')
+        _map.connect('/deposited-dataset/{id}/resource_data/{resource_id}', controller='ckanext.datapusher.plugin:ResourceDataController', action='resource_data')
+
+        # resource download routes
+        download_routes = [
+            '/dataset/{id}/resource/{resource_id}/download',
+            '/dataset/{id}/resource/{resource_id}/download/{filename}',
+            '/deposited-dataset/{id}/resource/{resource_id}/download',
+            '/deposited-dataset/{id}/resource/{resource_id}/download/{filename}',
+        ]
         if 'cloudstorage' not in config['ckan.plugins']:
-            _map.connect('/dataset/{id}/resource/{resource_id}/download', controller=controller, action='resource_download')
-            _map.connect('/dataset/{id}/resource/{resource_id}/download/{filename}', controller=controller, action='resource_download')
+            for route in download_routes:
+                _map.connect(route, controller=controller, action='resource_download')
         else:
             controller='ckanext.unhcr.controllers.extended_storage:ExtendedStorageController'
-            _map.connect('/dataset/{id}/resource/{resource_id}/download', controller=controller, action='resource_download')
-            _map.connect('/dataset/{id}/resource/{resource_id}/download/{filename}', controller=controller, action='resource_download')
+            for route in download_routes:
+                _map.connect(route, controller=controller, action='resource_download')
 
 
         # organization

--- a/ckanext/unhcr/templates/organization/read.html
+++ b/ckanext/unhcr/templates/organization/read.html
@@ -48,7 +48,9 @@
         <p>{% trans %}You have datasets which are not deposited yet:{% endtrans %}</p>
         <ul>
           {% for draft in drafts %}
-          <li><a href="/dataset/{{ draft.name }}">{{ draft.title }}</a></li>
+          <li><a href="{{ h.url_for('dataset_read', id=draft.name) }}">
+            {{ draft.title }}
+          </a></li>
           {% endfor %}
         </ul>
       </div>

--- a/ckanext/unhcr/templates/package/new_package_form.html
+++ b/ckanext/unhcr/templates/package/new_package_form.html
@@ -13,7 +13,10 @@
       <p>
         You are copying the
         "
-        <a id="dataset-title-value" href="/dataset/{{ data.original_dataset.name }}">
+        <a
+          id="dataset-title-value"
+          href="{{ h.url_for('dataset_read', id=data.original_dataset.name) }}"
+        >
           <strong>{{ data.original_dataset.title }}</strong>
         </a>
         "

--- a/ckanext/unhcr/templates/package/snippets/collaboration_modals.html
+++ b/ckanext/unhcr/templates/package/snippets/collaboration_modals.html
@@ -3,7 +3,13 @@
 <div id="collaboration-dataset-request-access" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <form action="/dataset/{{ pkg.id }}/request_access" method="POST">
+      <form
+        action="{% url_for
+          controller='ckanext.unhcr.controllers.extended_package:ExtendedPackageController',
+          action='request_access',
+          id=pkg.id %}"
+        method="POST"
+      >
 
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>

--- a/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
+++ b/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
@@ -43,7 +43,7 @@
         <a href="/deposited-dataset/edit/{{ pkg.id }}" class="btn btn-warning {% if editing %}disabled{% endif %}" {% if not editing %}title="{{ link_help }}"{% endif %}>
           {% trans %}Edit Dataset{% endtrans %}
         </a>
-        <a href="/dataset/resources/{{ pkg.id }}" class="btn btn-warning {% if editing %}disabled{% endif %}" {% if not editing %}title="{{ link_help }}"{% endif %}>
+        <a href="/deposited-dataset/resources/{{ pkg.id }}" class="btn btn-warning {% if editing %}disabled{% endif %}" {% if not editing %}title="{{ link_help }}"{% endif %}>
           {% trans %}Edit Resources{% endtrans %}
         </a>
       {% endif %}

--- a/ckanext/unhcr/templates/package/snippets/package_form.html
+++ b/ckanext/unhcr/templates/package/snippets/package_form.html
@@ -45,7 +45,14 @@ then itself be extended to add/remove blocks of functionality. #}
 
       {% if data.state == 'draft' and data.resources %}
         <button class="btn" type="submit" name="save">{{ _('Add More Data') }}</button>
-        <a href="/dataset/publish/{{ data.id }}" class="btn btn-primary">{{ _('Publish Dataset') }}</a>
+        <a
+          href="{% url_for
+            controller='ckanext.unhcr.controllers.extended_package:ExtendedPackageController',
+            action='publish',
+            id=data.id %}"
+          class="btn btn-primary">
+            {{ _('Publish Dataset') }}
+        </a>
       {% else %}
         {% block save_button %}
           <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>

--- a/ckanext/unhcr/templates/package/snippets/publish_modals.html
+++ b/ckanext/unhcr/templates/package/snippets/publish_modals.html
@@ -5,7 +5,12 @@
     <div class="modal-dialog" role="document">
     <div class="modal-content">
 
-    <form action="/dataset/{{ pkg.id }}/publish_microdata">
+    <form
+      action="{% url_for
+        controller='ckanext.unhcr.controllers.extended_package:ExtendedPackageController',
+        action='publish_microdata',
+        id=pkg.id %}"
+    >
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
         <h3>Push to Microdata</h3>


### PR DESCRIPTION
Refs #372

This branch is based off the work in https://github.com/okfn/ckanext-unhcr/pull/389 so 1b56308 - 978c873 are from that branch/PR. Only f38fe3b - 501c26a are new here.
Review of this is basically irrelevant until #389 is reviewed but I don't want to just keep blocking all progress on the EDD. Once that is sorted, I'll rebase this.

Because `url_for` can deal with a variety of different input styles, I decided to resolve the URL first and then manipulate it as a post-process rather than trying to work with the input params.