### PR TITLE
Set up access controls for external users

### DIFF
--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -166,7 +166,7 @@ def package_update(next_auth, context, data_dict):
     # Deposited dataset
     if dataset['type'] == 'deposited-dataset':
         curation = helpers.get_deposited_dataset_user_curation_status(
-            dataset, toolkit.c.userobj.id)
+            dataset, getattr(context.get('auth_user_obj'), 'id', None))
         if 'edit' in curation['actions']:
             return {'success': True}
         return {'success': False, 'msg': 'Not authorized to edit deposited dataset'}

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -77,6 +77,20 @@ def organization_list_for_user(context, data_dict):
         return core_get.organization_list_for_user(context, data_dict)
 
 
+@toolkit.chained_auth_function
+def organization_show(next_auth, context, data_dict):
+    user = context.get('auth_user_obj')
+    if not user:
+        return next_auth(context, data_dict)
+    if user.external:
+        deposit = helpers.get_data_deposit()
+        if data_dict.get('id') in [deposit['name'], deposit['id']]:
+            return {'success': True}
+        else:
+            return {'success': False}
+    return next_auth(context, data_dict)
+
+
 def organization_create(context, data_dict):
     user_orgs = toolkit.get_action('organization_list_for_user')(context, {})
 

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -128,18 +128,27 @@ def organization_create(context, data_dict):
 # Package
 
 def package_create(context, data_dict):
-
     # Data deposit
     if not data_dict:
-        # All users can deposit datasets
-        if toolkit.request.path == '/deposited-dataset/new':
-            return {'success': True}
+        try:
+            # All users can deposit datasets
+            if (
+                toolkit.request.path == '/deposited-dataset/new' or
+                toolkit.request.path.startswith('/deposited-dataset/edit/')
+            ):
+                return {'success': True}
+        except TypeError:
+            return {
+                'success': False,
+                'msg': 'package_create requires either a web request or a data_dict'
+            }
     else:
         deposit = helpers.get_data_deposit()
         if deposit['id'] == data_dict.get('owner_org'):
             return {'success': True}
 
     # Data container
+    context['model'] = context.get('model') or model
     return auth_create_core.package_create(context, data_dict)
 
 

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -46,8 +46,8 @@ def url_for(*args, **kw):
 
 # General
 
-def get_data_container(id, context=None):
-    context = context or {'model': model}
+def get_data_container(id):
+    context = {'model': model, 'ignore_auth': True}
     return toolkit.get_action('organization_show')(context, {'id': id})
 
 

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -287,8 +287,8 @@ def get_data_deposit():
     return deposit
 
 
-def get_data_curation_users(context=None):
-    context = context or {'model': model, 'user': toolkit.c.user}
+def get_data_curation_users():
+    context = {'model': model, 'ignore_auth': True}
     deposit = get_data_deposit()
 
     # Get depadmins

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -320,10 +320,11 @@ def get_data_curation_users():
 
 def get_deposited_dataset_user_curation_status(dataset, user_id):
     deposit = get_data_deposit()
+    context = {'user': user_id, 'model': model, 'session': model.Session}
 
     # General
     status = {}
-    status['error'] = get_dataset_validation_error_or_none(dataset)
+    status['error'] = get_dataset_validation_error_or_none(dataset, context)
     status['role'] = get_deposited_dataset_user_curation_role(user_id)
     status['state'] = dataset['curation_state']
     status['final_review'] = dataset.get('curation_final_review')
@@ -421,9 +422,7 @@ def get_deposited_dataset_user_contact(user_id=None):
     }
 
 
-def get_dataset_validation_error_or_none(pkg_dict, context=None):
-    context = context or {'model': model, 'session': model.Session, 'user': toolkit.c.user}
-
+def get_dataset_validation_error_or_none(pkg_dict, context):
     # Convert dataset
     if pkg_dict.get('type') == 'deposited-dataset':
         pkg_dict = convert_deposited_dataset_to_regular_dataset(pkg_dict)

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -29,6 +29,27 @@ _ = toolkit._
 
 
 INTERNAL_DOMAINS = ['unhcr.org']
+ALLOWED_ACTIONS = [
+    'group_list_authz',
+    'group_list',
+    'group_show',
+    'organization_list_for_user',
+    'organization_show',
+    'package_create',
+    'package_delete',
+    'package_patch',
+    'package_resource_reorder',
+    'package_search',
+    'package_show',
+    'package_update',
+    'resource_create',
+    'resource_delete',
+    'resource_download',
+    'resource_patch',
+    'resource_show',
+    'resource_update',
+    'resource_view_list',
+]
 
 
 def user_is_external(user):
@@ -56,11 +77,6 @@ def restrict_external(func):
     '''
     Decorator function to restrict external users to a small number of allowed_actions
     '''
-
-    allowed_actions = [
-        'package_search',
-    ]
-
     def wrapper(action, context, data_dict=None):
         user = User.by_name(context.get('user'))
         if not user:
@@ -69,7 +85,7 @@ def restrict_external(func):
             return func(action, context, data_dict)
         if context.get('ignore_auth'):
             return func(action, context, data_dict)
-        if user.external and action not in allowed_actions:
+        if user.external and action not in ALLOWED_ACTIONS:
             return {'success': False, 'msg': 'Not allowed to perform this action'}
         return func(action, context, data_dict)
     return wrapper

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -489,6 +489,7 @@ class UnhcrPlugin(
         functions['unhcr_datastore_search_sql'] = auth.unhcr_datastore_search_sql
         functions['datasets_validation_report'] = auth.datasets_validation_report
         functions['organization_create'] = auth.organization_create
+        functions['organization_show'] = auth.organization_show
         functions['package_activity_list'] = auth.package_activity_list
         functions['package_create'] = auth.package_create
         functions['package_update'] = auth.package_update

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -582,7 +582,7 @@ class UnhcrPlugin(
         if user_obj:
 
             if user_obj.external:
-                return ['']
+                return ['creator-%s' % user_obj.id]
 
             context = {u'user': user_obj.id}
             deposit = helpers.get_data_deposit()

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -197,6 +197,8 @@ class UnhcrPlugin(
         _map.connect('/deposited-dataset/{id}/resource_edit/{resource_id}', controller=controller, action='resource_edit')
         _map.connect('/deposited-dataset/{id}/resource/{resource_id}', controller=controller, action='resource_read')
         _map.connect('/deposited-dataset/{id}/resource/{resource_id}/view/{view_id}', controller=controller, action='resource_view')
+        _map.connect('/deposited-dataset/new_resource/{id}', controller=controller, action='new_resource')
+        _map.connect('/deposited-dataset/publish/{id}', controller=controller, action='publish')
         _map.connect('/deposited-dataset/activity/{dataset_id}', controller=controller, action='activity')
         _map.connect('/deposited-dataset/activity/{dataset_id}/{offset}', controller=controller, action='activity')
         _map.connect('/deposited-dataset/copy/{id}', controller=controller, action='copy')

--- a/ckanext/unhcr/templates/package/read_base.html
+++ b/ckanext/unhcr/templates/package/read_base.html
@@ -14,11 +14,16 @@
 {% block content_primary_nav %}
   {% if pkg.type == 'deposited-dataset' %}
     {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
-  	{{ h.build_nav_icon('%s_internal_activity' % dataset_type, _('Internal Activity'), dataset_id=pkg.name, icon='gavel') }}
+    {% if h.check_access('package_activity_list', {'user': c.user, 'id': pkg.id}) %}
+      {{ h.build_nav_icon('%s_internal_activity' % dataset_type, _('Internal Activity'), dataset_id=pkg.name, icon='gavel') }}
+    {% endif %}
   {% else %}
     {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
     {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
-    {% if h.check_access('package_update', {'user': c.user, 'id': c.pkg_dict.id}) %}
+    {% if (
+      h.check_access('package_update', {'user': c.user, 'id': pkg.id}) and
+      h.check_access('package_activity_list', {'user': c.user, 'id': pkg.id})
+    ) %}
       {{ h.build_nav_icon('%s_internal_activity' % dataset_type, _('Internal Activity'), dataset_id=pkg.name, icon='gavel') }}
     {% endif %}
   {% endif %}

--- a/ckanext/unhcr/templates/scheming/display_snippets/owner_org_dest.html
+++ b/ckanext/unhcr/templates/scheming/display_snippets/owner_org_dest.html
@@ -3,5 +3,9 @@
   Unknown
 {% else %}
   {% set data_container = h.get_data_container(value) %}
-  <a href="{{ h.url_for('data-container_read', id=data_container.name) }}">{{ data_container.title }}</a>
+  {% if c.userobj.external %}
+    {{ data_container.title }}
+  {% else %}
+    <a href="{{ h.url_for('data-container_read', id=data_container.name) }}">{{ data_container.title }}</a>
+  {% endif %}
 {% endif %}

--- a/ckanext/unhcr/tests/test_auth.py
+++ b/ckanext/unhcr/tests/test_auth.py
@@ -323,40 +323,65 @@ class TestAuthUnit(base.FunctionalTestBase):
                         context=context
                     )
 
-    # TODO: fix problems with context pupulation
-    #  def test_package_update(self):
+    def test_package_update(self):
 
-        #  # Create users
-        #  depadmin = core_factories.User(name='depadmin')
-        #  curator = core_factories.User(name='curator')
-        #  depositor = core_factories.User(name='depositor')
-        #  creator = core_factories.User(name='creator')
+        # Create users
+        depadmin = core_factories.User(name='depadmin')
+        curator = core_factories.User(name='curator')
+        depositor = core_factories.User(name='depositor')
+        creator = core_factories.User(name='creator')
 
-        #  # Create containers
-        #  deposit = factories.DataContainer(
-            #  id='data-deposit',
-            #  name='data-deposit',
-            #  users=[
-                #  {'name': 'depadmin', 'capacity': 'admin'},
-                #  {'name': 'curator', 'capacity': 'editor'},
-            #  ],
-        #  )
-        #  target = factories.DataContainer(
-            #  id='data-target',
-            #  name='data-target',
-        #  )
+        # Create containers
+        deposit = factories.DataContainer(
+            id='data-deposit',
+            name='data-deposit',
+            users=[
+                {'name': 'depadmin', 'capacity': 'admin'},
+                {'name': 'curator', 'capacity': 'editor'},
+            ],
+        )
+        target = factories.DataContainer(
+            id='data-target',
+            name='data-target',
+        )
 
-        #  # Create dataset
-        #  dataset = factories.DepositedDataset(
-            #  name='dataset',
-            #  owner_org='data-deposit',
-            #  owner_org_dest='data-target',
-            #  user=creator)
+        # Create dataset
+        dataset = factories.DepositedDataset(
+            name='dataset',
+            owner_org='data-deposit',
+            owner_org_dest='data-target',
+            user=creator
+        )
 
-        #  # Forbidden depadmin/curator/depositor
-        #  assert_equals(auth.package_update({'user': 'depadmin'}, dataset), False)
-        #  assert_equals(auth.package_update({'user': 'curator'}, dataset), False)
-        #  assert_equals(auth.package_update({'user': 'depositor'}, dataset), False)
+        # Forbidden depadmin/curator/depositor
+        assert_raises(
+            toolkit.NotAuthorized,
+            toolkit.check_access,
+            'package_update',
+            context={'user': 'depadmin'},
+            data_dict={'id': dataset['id']},
+        )
+        assert_raises(
+            toolkit.NotAuthorized,
+            toolkit.check_access,
+            'package_update',
+            context={'user': 'curator'},
+            data_dict={'id': dataset['id']},
+        )
+        assert_raises(
+            toolkit.NotAuthorized,
+            toolkit.check_access,
+            'package_update',
+            context={'user': 'depositor'},
+            data_dict={'id': dataset['id']},
+        )
 
-        #  # Granted creator
-        #  assert_equals(auth.package_update({'user': 'creator'}, dataset), True)
+        # Granted creator
+        assert_equals(
+            True,
+            toolkit.check_access(
+                'package_update',
+                {'user': 'creator'},
+                {'id': dataset['id']}
+            )
+        )

--- a/ckanext/unhcr/tests/test_helpers.py
+++ b/ckanext/unhcr/tests/test_helpers.py
@@ -19,17 +19,13 @@ class TestHelpers(base.FunctionalTestBase):
     # General
 
     def test_get_data_container(self):
-        user = core_factories.User()
-        context = {'model': model, 'user': user['name']}
         container = factories.DataContainer(title='container1')
-        result = helpers.get_data_container(container['id'], context=context)
+        result = helpers.get_data_container(container['id'])
         assert_equals(result['title'], container['title'])
 
     def test_get_data_container_not_found(self):
-        user = core_factories.User()
-        context = {'model': model, 'user': user['name']}
         assert_raises(toolkit.ObjectNotFound,
-            helpers.get_data_container, 'bad-id', context=context)
+            helpers.get_data_container, 'bad-id')
 
     def test_get_all_data_containers(self):
         container1 = factories.DataContainer(title='container1')

--- a/ckanext/unhcr/tests/test_helpers.py
+++ b/ckanext/unhcr/tests/test_helpers.py
@@ -203,7 +203,7 @@ class TestHelpers(base.FunctionalTestBase):
                 {'name': 'curator2', 'capacity': 'editor'},
             ],
         )
-        curators = helpers.get_data_curation_users(context={'user': 'depadmin'})
+        curators = helpers.get_data_curation_users()
         curator_names = sorted([curator['name']
             for curator in curators
             # Added to org by ckan

--- a/ckanext/unhcr/tests/test_helpers.py
+++ b/ckanext/unhcr/tests/test_helpers.py
@@ -231,7 +231,8 @@ class TestHelpers(base.FunctionalTestBase):
 
     def test_get_dataset_validation_error_or_none_valid(self):
         dataset = factories.Dataset(name='name', title='title')
-        error = helpers.get_dataset_validation_error_or_none(dataset)
+        context = {'model': model, 'session': model.Session, 'ignore_auth': True ,'user': None}
+        error = helpers.get_dataset_validation_error_or_none(dataset, context)
         assert_equals(error, None)
 
     def test_convert_deposited_dataset_to_regular_dataset(self):


### PR DESCRIPTION
Refs #375

In this PR, I have focussed on granting external users a minimal set of authorizations necessary to create deposited datasets and interact with their own datasets in the data deposit container.

I haven't attempted to do anything with the interface for accomplishing this task - I'm just focussing on permissions here. I also haven't done anything about the user management permissions yet. I think this is probably enough to review at one time.

Note this PR is targetted at the long-running `external-data-deposit` branch (not `master`) which I've already merged #389 and #400 onto but it won't affect what we're shipping to users yet.

This shouldn't be too hard to review hopefully - I've split it into lots of commits making small changes with plenty of explanation.