### PR TITLE
External User Signup process

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -2,6 +2,7 @@ import json
 import logging
 import requests
 from sqlalchemy import and_, desc, or_, select
+from sqlalchemy.dialects.postgresql import array
 from ckan import model
 from ckan.authz import has_user_permission_for_group_or_org
 from ckan.plugins import toolkit
@@ -586,6 +587,10 @@ def access_request_list_for_user(context, data_dict):
                 AccessRequest.object_type == "organization",
                 AccessRequest.object_id.in_(containers),
             ),
+            and_(
+                AccessRequest.object_type == "user",
+                AccessRequest.data["containers"].has_any(array(containers)),
+            )
         )
     )
 

--- a/ckanext/unhcr/blueprints/access_requests.py
+++ b/ckanext/unhcr/blueprints/access_requests.py
@@ -48,8 +48,11 @@ def reject(request_id):
         obj = toolkit.get_action('{}_show'.format(request['object_type']))(
             {'user': toolkit.c.user}, {'id': request['object_id']}
         )
-        subj = mailer.compose_request_rejected_email_subj(obj)
-        body = mailer.compose_request_rejected_email_body(recipient, obj, message)
+        if request['object_type'] == 'user':
+            subj = '[UNHCR RIDL] - User account rejected'
+        else:
+            subj = mailer.compose_request_rejected_email_subj(obj)
+        body = mailer.compose_request_rejected_email_body(request['object_type'], recipient, obj, message)
         mailer.mail_user_by_id(recipient.name, subj, body)
     except toolkit.ObjectNotFound as e:
         return toolkit.abort(404, toolkit._(str(e)))

--- a/ckanext/unhcr/blueprints/data_container.py
+++ b/ckanext/unhcr/blueprints/data_container.py
@@ -59,7 +59,7 @@ def request_access(container_id):
         if e.error_dict and 'message' in e.error_dict:
             return toolkit.abort(
                 400,
-                e.error_dict['message'].replace('organization', 'container')
+                e.error_dict['message'][0].replace('organization', 'container')
             )
         return toolkit.abort(400, 'Bad Request')
 

--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -102,6 +102,8 @@ class RegisterView(BaseRegisterView):
 
         context['defer_commit'] = True
         data_dict['state'] = context['model'].State.PENDING
+        deposit = get_data_deposit()
+        containers = [data_dict.get('container'), deposit['id']]
 
         try:
             model.Session.begin_nested()
@@ -112,7 +114,7 @@ class RegisterView(BaseRegisterView):
                 'object_type': 'user',
                 'message': data_dict['message'],
                 'role': 'member',
-                'data': {'containers': [data_dict.get('container')]}
+                'data': {'containers': containers}
             }
             toolkit.get_action(u'access_request_create')(
                 {'user': user['id'], 'ignore_auth': True, 'defer_commit': True},
@@ -136,7 +138,7 @@ class RegisterView(BaseRegisterView):
             raise
 
         recipients = mailer.get_user_account_request_access_email_recipients(
-            [data_dict.get('container')]
+            containers
         )
         for recipient in recipients:
             subj = mailer.compose_user_request_access_email_subj()

--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 
+import logging
 from flask import Blueprint
+import ckan.lib.captcha as captcha
+import ckan.lib.navl.dictization_functions as dictization_functions
+import ckan.logic as logic
 import ckan.plugins.toolkit as toolkit
+from ckan.views.user import RegisterView as BaseRegisterView
+from ckanext.unhcr.utils import get_internal_domains
+
+log = logging.getLogger(__name__)
+_ = toolkit._
 
 
 unhcr_user_blueprint = Blueprint('unhcr_user', __name__, url_prefix=u'/user')
@@ -30,8 +39,80 @@ def sysadmin():
     return toolkit.h.redirect_to('unhcr_admin.index')
 
 
+class RegisterView(BaseRegisterView):
+
+    def post(self):
+        context = self._prepare()
+        try:
+            data_dict = logic.clean_dict(
+                dictization_functions.unflatten(
+                    logic.tuplize_dict(logic.parse_params(toolkit.request.form))))
+        except dictization_functions.DataError:
+            toolkit.abort(400, _(u'Integrity Error'))
+
+        context[u'message'] = data_dict.get(u'log_message', u'')
+        try:
+            captcha.check_recaptcha(toolkit.request)
+        except captcha.CaptchaError:
+            error_msg = _(u'Bad Captcha. Please try again.')
+            toolkit.h.flash_error(error_msg)
+            return self.get(data_dict)
+
+        try:
+            domain = toolkit.request.form['email'].split('@')[1]
+        except IndexError:
+            message = 'Please enter an email address'
+            return self.get(data_dict, {'email': [message]}, {'email': message})
+
+        if domain in get_internal_domains():
+            message = (
+                'Users with an @{domain} email may not register for an external account. '.format(
+                    domain=domain
+                ) + 'Log in to {site} using {email} and use your Active Directory password to access RIDL'.format(
+                    site=toolkit.config.get('ckan.site_url'),
+                    email=toolkit.request.form['email']
+                )
+            )
+            return self.get(data_dict, {'email': [message]}, {'email': message})
+
+        try:
+            data_dict['state'] = context['model'].State.PENDING
+            toolkit.get_action(u'user_create')(context, data_dict)
+        except toolkit.NotAuthorized:
+            toolkit.abort(403, _(u'Unauthorized to create user %s') % u'')
+        except toolkit.ObjectNotFound:
+            toolkit.abort(404, _(u'User not found'))
+        except toolkit.ValidationError as e:
+            errors = e.error_dict
+            error_summary = e.error_summary
+            return self.get(data_dict, errors, error_summary)
+
+        if toolkit.c.user:
+            # #1799 User has managed to register whilst logged in - warn user
+            # they are not re-logged in as new user.
+            toolkit.h.flash_success(
+                _(u'User "%s" is now registered but you are still '
+                  u'logged in as "%s" from before') % (data_dict[u'name'],
+                                                       toolkit.c.user))
+            try:
+                toolkit.check_access('sysadmin', context)
+                return toolkit.h.redirect_to(u'user.activity', id=data_dict[u'name'])
+            except toolkit.NotAuthorized:
+                return toolkit.render(u'user/logout_first.html')
+
+        return toolkit.render(
+            u'user/account_created.html',
+            {'email': data_dict['email']}
+        )
+
+
 unhcr_user_blueprint.add_url_rule(
     rule=u'/sysadmin',
     view_func=sysadmin,
     methods=['POST',],
+)
+
+unhcr_user_blueprint.add_url_rule(
+    u'/register',
+    view_func=RegisterView.as_view(str(u'register'))
 )

--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -10,6 +10,7 @@ import ckan.plugins.toolkit as toolkit
 from ckan.views.user import RegisterView as BaseRegisterView
 from ckanext.unhcr.helpers import get_data_deposit
 from ckanext.unhcr.utils import get_internal_domains
+from ckanext.unhcr import mailer
 
 log = logging.getLogger(__name__)
 _ = toolkit._
@@ -133,6 +134,20 @@ class RegisterView(BaseRegisterView):
         except:
             model.Session.rollback()
             raise
+
+        recipients = mailer.get_user_account_request_access_email_recipients(
+            [data_dict.get('container')]
+        )
+        for recipient in recipients:
+            subj = mailer.compose_user_request_access_email_subj()
+            body = mailer.compose_request_access_email_body(
+                'user',
+                recipient,
+                user,
+                user,
+                data_dict['message']
+            )
+            mailer.mail_user_by_id(recipient['name'], subj, body)
 
         if toolkit.c.user:
             # #1799 User has managed to register whilst logged in - warn user

--- a/ckanext/unhcr/controllers/extended_package.py
+++ b/ckanext/unhcr/controllers/extended_package.py
@@ -219,7 +219,7 @@ class ExtendedPackageController(PackageController):
             if e.error_dict and 'message' in e.error_dict:
                 return toolkit.abort(
                     400,
-                    e.error_dict['message'].replace('package', 'dataset')
+                    e.error_dict['message'][0].replace('package', 'dataset')
                 )
             return toolkit.abort(400, 'Bad Request')
 

--- a/ckanext/unhcr/controllers/extended_user.py
+++ b/ckanext/unhcr/controllers/extended_user.py
@@ -37,12 +37,16 @@ class ExtendedUserController(UserController):
         dataset_access_requests = [
             req for req in access_requests if req['object_type'] == 'package'
         ]
+        user_account_requests = [
+            req for req in access_requests if req['object_type'] == 'user'
+        ]
 
         return toolkit.render('user/dashboard_requests.html', {
             'user_dict': context['user'],
             'new_container_requests': new_container_requests,
             'container_access_requests': container_access_requests,
             'dataset_access_requests': dataset_access_requests,
+            'user_account_requests': user_account_requests,
         })
 
     # Private

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -131,15 +131,27 @@ def page_authorized():
         return True
 
     # TODO: remove request_reset and perform_reset when LDAP is integrated
+    allowed_controllers = [
+        'user',  # most actions are defined in the core 'user' blueprint
+        'unhcr_user',  # we override some actions in the 'unhcr_user' blueprint
+    ]
+    allowed_actions = [
+        'logged_in',
+        'logged_out',
+        'logged_out_page',
+        'logged_out_redirect',
+        'login',
+        'perform_reset',
+        'register',
+        'request_reset',
+    ]
     return (
-        toolkit.c.userobj or
-        (toolkit.c.controller == 'user' and
-            toolkit.c.action in [
-                'login', 'logged_in', 'request_reset', 'perform_reset',
-                'logged_out', 'logged_out_page', 'logged_out_redirect'
-                ]
-        ) or
-        toolkit.request.path == '/service/login'
+        toolkit.c.userobj
+        or (
+            toolkit.c.controller in allowed_controllers
+            and toolkit.c.action in allowed_actions
+        )
+        or toolkit.request.path == '/service/login'
     )
 
 

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -174,10 +174,12 @@ def user_is_curator():
     return user_id in user_ids
 
 
-def user_is_container_admin():
+def user_is_container_admin(user=None):
+    if not user:
+        user = toolkit.c.user
     orgs = toolkit.get_action("organization_list_for_user")(
-        {"user": toolkit.c.user},
-        {"id": toolkit.c.user, "permission": "admin"}
+        {"user": user},
+        {"id": user, "permission": "admin"}
     )
     return len(orgs) > 0
 

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -272,8 +272,10 @@ def get_dataset_request_access_email_recipients(package_dict):
 def get_user_account_request_access_email_recipients(containers):
     # This email is sent to admins of all containers in `containers` arg plus sysadmins
     recipients = _get_sysadmins()
-    for c in containers:
-        recipients = recipients + get_container_request_access_email_recipients({"id": c})
+    for container in containers:
+        recipients = recipients + get_container_request_access_email_recipients(
+            {"id": container}
+        )
     recipients = [dict(tup) for tup in {tuple(r.items()) for r in recipients}]  # de-dupe
     return recipients
 

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -312,10 +312,25 @@ def compose_request_rejected_email_subj(obj):
     return '[UNHCR RIDL] - Request for access to: "{}"'.format(obj['name'])
 
 
-def compose_request_rejected_email_body(recipient, obj, message):
+def compose_request_rejected_email_body(object_type, recipient, obj, message):
     context = {}
+    context['object_type'] = object_type
     context['recipient'] = recipient
     context['object'] = obj
     context['message'] = message
     context['h'] = toolkit.h
+
     return render_jinja2('emails/access_requests/rejection.html', context)
+
+
+def compose_account_approved_email_subj():
+    return '[UNHCR RIDL] - User account approved'
+
+
+def compose_account_approved_email_body(recipient):
+    context = {}
+    context['recipient'] = recipient
+    context['login_url'] = toolkit.url_for('/service/login', qualified=True)
+    context['h'] = toolkit.h
+
+    return render_jinja2('emails/user/account_approved.html', context)

--- a/ckanext/unhcr/models.py
+++ b/ckanext/unhcr/models.py
@@ -4,7 +4,9 @@ import datetime
 import logging
 
 from sqlalchemy import Column, DateTime, Integer
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.types import Enum, UnicodeText
 
 from ckan.model.meta import metadata
@@ -43,10 +45,11 @@ class AccessRequest(Base):
         nullable=False,
     )
     object_type = Column(
-        Enum('package', 'organization', name='access_request_object_type_enum'),
+        Enum('package', 'organization', 'user', name='access_request_object_type_enum'),
         nullable=False,
     )
     object_id = Column(UnicodeText, nullable=False)
+    data = Column(MutableDict.as_mutable(JSONB), nullable=True)
 
 
 def create_metric_columns():
@@ -62,6 +65,33 @@ def create_metric_columns():
     model.Session.commit()
 
 
+def extend_access_request_object_type_enum():
+    # We can't modify the enum in-place inside a transaction on Postgres < 12
+    # it will throw 'ALTER TYPE ... ADD cannot run inside a transaction block'
+    # so we're going to..
+
+    # swtich to isolation_level = AUTOCOMMIT
+    model.Session.connection().connection.set_isolation_level(0)
+
+    # modify the enum in-place
+    model.Session.execute(
+        u"ALTER TYPE access_request_object_type_enum ADD VALUE IF NOT EXISTS 'user';"
+    )
+
+    # switch back to isolation_level = READ_COMMITTED
+    model.Session.connection().connection.set_isolation_level(1)
+
+
+def add_access_request_data_column():
+    table = AccessRequest.__tablename__
+    model.Session.execute(
+        u"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS data JSONB;".format(
+            table=table
+        )
+    )
+    model.Session.commit()
+
+
 def create_tables():
     if not TimeSeriesMetric.__table__.exists():
         TimeSeriesMetric.__table__.create()
@@ -69,6 +99,10 @@ def create_tables():
 
     create_metric_columns()
 
+
     if not AccessRequest.__table__.exists():
         AccessRequest.__table__.create()
         log.info(u'AccessRequest database table created')
+
+    add_access_request_data_column()
+    extend_access_request_object_type_enum()

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -18,7 +18,7 @@ from ckan.lib.activity_streams import (
     activity_stream_string_icons,
 )
 
-from ckanext.unhcr import actions, auth, blueprints, helpers, jobs, validators
+from ckanext.unhcr import actions, auth, blueprints, helpers, jobs, utils, validators
 
 from ckanext.scheming.helpers import scheming_get_dataset_schema
 from ckanext.hierarchy.helpers import group_tree_section
@@ -28,7 +28,6 @@ log = logging.getLogger(__name__)
 _ = toolkit._
 
 
-INTERNAL_DOMAINS = ['unhcr.org']
 ALLOWED_ACTIONS = [
     'group_list_authz',
     'group_list',
@@ -65,12 +64,7 @@ def user_is_external(user):
         else:
             return True
 
-    internal_domains = toolkit.aslist(
-        toolkit.config.get('ckanext.unhcr.internal_domains', INTERNAL_DOMAINS),
-        sep = ','
-    )
-
-    return domain not in internal_domains
+    return domain not in utils.get_internal_domains()
 
 
 def restrict_external(func):

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -492,6 +492,7 @@ class UnhcrPlugin(
         functions['access_request_create'] = auth.access_request_create
         functions['access_request_update'] = auth.access_request_update
         functions['user_update_sysadmin'] = auth.user_update_sysadmin
+        functions['external_user_update_state'] = auth.external_user_update_state
         functions['search_index_rebuild'] = auth.search_index_rebuild
         return functions
 
@@ -523,6 +524,7 @@ class UnhcrPlugin(
             'recently_changed_packages_activity_list_html': actions.recently_changed_packages_activity_list_html,
             'datasets_validation_report': actions.datasets_validation_report,
             'user_update_sysadmin': actions.user_update_sysadmin,
+            'external_user_update_state': actions.external_user_update_state,
             'search_index_rebuild': actions.search_index_rebuild,
         }
 

--- a/ckanext/unhcr/templates/emails/access_requests/access_request.html
+++ b/ckanext/unhcr/templates/emails/access_requests/access_request.html
@@ -8,7 +8,7 @@
   {% endcall %}
 
   {% call email.paragraph() %}
-    User
+    {% if object_type == 'user' %}External user{% else %}User{% endif %}
     {{ h.link_to(requesting_user.fullname or requesting_user.name, h.url_for('user.read', id=requesting_user.id, qualified=True)) }}
 
     {% if object_type == 'dataset' %}
@@ -17,6 +17,8 @@
     {% elif object_type == 'container' %}
       has requested access to
       {{ h.link_to(object.display_name, h.url_for('data-container_read', id=object.name, qualified=True)) }}.
+    {% elif object_type == 'user' %}
+      has requested access to deposit datasets.
     {% else %}
       has requested access to <strong>{{ object.name }}</strong>
     {% endif %}
@@ -32,11 +34,11 @@
   {% endcall %}
 
   {% call email.paragraph() %}
-    To add the user as a collaborator, visit the following page (logged in with your administrator account):
+    To approve or reject the request, visit the following page (logged in with your administrator account):
   {% endcall %}
 
-  {% call email.action(collaborators_url) %}
-    Add Collaborator
+  {% call email.action(dashboard_url) %}
+    Dashboard
   {% endcall %}
 
 {% endblock %}

--- a/ckanext/unhcr/templates/emails/access_requests/rejection.html
+++ b/ckanext/unhcr/templates/emails/access_requests/rejection.html
@@ -8,9 +8,13 @@ Dear <b>{{ recipient.fullname or recipient.name }}</b>,
 {% endcall %}
 
   {% call email.paragraph() %}
-    Your request to access
-    <strong>{{ object.title or object.name }}</strong>
-    has been rejected.
+    {% if object_type == 'user' %}
+      Your request for a RIDL user account has been rejected.
+    {% else %}
+      Your request to access
+      <strong>{{ object.title or object.name }}</strong>
+      has been rejected.
+    {% endif %}
   {% endcall %}
 
   {% call email.paragraph() %}

--- a/ckanext/unhcr/templates/emails/user/account_approved.html
+++ b/ckanext/unhcr/templates/emails/user/account_approved.html
@@ -1,0 +1,18 @@
+{% extends "emails/base.html" %}
+{% import 'macros/email.html' as email with context %}
+
+{% block email_body %}
+
+{% call email.paragraph() %}
+Dear <b>{{ recipient.fullname or recipient.name }}</b>,
+{% endcall %}
+
+  {% call email.paragraph() %}
+      Your request for a RIDL user account has been approved by an administrator.
+  {% endcall %}
+
+  {% call email.action(login_url) %}
+    Log In
+  {% endcall %}
+
+{% endblock %}

--- a/ckanext/unhcr/templates/user/account_created.html
+++ b/ckanext/unhcr/templates/user/account_created.html
@@ -1,0 +1,36 @@
+{% extends "page.html" %}
+
+{% block primary_content %}
+  <article class="module">
+    <div class="module-content">
+      {% block primary_content_inner %}
+      <h1 class="page-heading">
+        {% block page_heading %}{{ _('External Account Requested') }}{% endblock %}
+      </h1>
+      <h2>Thanks for registering</h2>
+      <p>
+        We'll send an email with further instructions to
+        <strong>{{ email }}</strong>
+        once your request has been reviewed by a moderator.
+      </p>
+      {% endblock %}
+    </div>
+  </article>
+{% endblock %}
+
+{% block secondary %}
+<aside class="secondary col-sm-3">
+  <div class="module module-narrow module-shallow">
+    <h2 class="module-heading">
+      <i class="fa fa-book"></i>
+      User Guide
+    </h2>
+    <div class="module-content">
+      <p>
+        <a href="https://im.unhcr.org/ridl/#externaldeposit" target="_blank">
+          More guidance on using RIDL</a>.
+      </p>
+    </div>
+  </div>
+</aside>
+{% endblock %}

--- a/ckanext/unhcr/templates/user/dashboard_requests.html
+++ b/ckanext/unhcr/templates/user/dashboard_requests.html
@@ -79,10 +79,25 @@
     </p>
   {% endif %}
 
+  <h2><i class="fa fa-user"></i>Requests for new User Accounts</h2>
+  <hr>
+  {% if user_account_requests %}
+    {% snippet
+      'user/snippets/access_request_list.html',
+      requests=user_account_requests,
+      table_type='User'
+    %}
+  {% else %}
+    <p class="empty">
+      No outstanding requests
+    </p>
+  {% endif %}
+
 {% endblock %}
 
 {% block footer %}
   {{ super() }}
   {% snippet 'user/snippets/access_request_modals.html', requests=container_access_requests %}
   {% snippet 'user/snippets/access_request_modals.html', requests=dataset_access_requests %}
+  {% snippet 'user/snippets/access_request_modals.html', requests=user_account_requests %}
 {% endblock %}

--- a/ckanext/unhcr/templates/user/new.html
+++ b/ckanext/unhcr/templates/user/new.html
@@ -1,0 +1,37 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Register') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Registration'), named_route='user.register') }}</li>
+{% endblock %}
+
+{% block primary_content %}
+  <article class="module">
+    <div class="module-content">
+      {% block primary_content_inner %}
+      <h1 class="page-heading">
+        {% block page_heading %}{{ _('Request an External Account') }}{% endblock %}
+      </h1>
+      {{ form | safe }}
+      {% endblock %}
+    </div>
+  </article>
+{% endblock %}
+
+{% block secondary %}
+<aside class="secondary col-sm-3">
+  <div class="module module-narrow module-shallow">
+    <h2 class="module-heading">
+      <i class="fa fa-book"></i>
+      User Guide
+    </h2>
+    <div class="module-content">
+      <p>
+        <a href="https://im.unhcr.org/ridl/#externaldeposit" target="_blank">
+          More guidance on using RIDL</a>.
+      </p>
+    </div>
+  </div>
+</aside>
+{% endblock %}

--- a/ckanext/unhcr/templates/user/new_user_form.html
+++ b/ckanext/unhcr/templates/user/new_user_form.html
@@ -1,0 +1,42 @@
+{% import "macros/form.html" as form %}
+
+<form id="user-register-form" action="" method="post">
+  {{ form.errors(error_summary) }}
+  {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"], is_required=True) }}
+  {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"]) }}
+  {{ form.input("email", id="field-email", label=_("Email"), type="email", placeholder=_("joe@example.com"), value=data.email, error=errors.email, classes=["control-medium"], is_required=True) }}
+  {{ form.input("password1", id="field-password", label=_("Password"), type="password", placeholder="••••••••", value=data.password1, error=errors.password1, classes=["control-medium"], is_required=True) }}
+  {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password1, classes=["control-medium"], is_required=True) }}
+  {{ form.textarea(
+      "message",
+      id="field-message",
+      label=_("Please describe the dataset(s) you would like to submit to UNHCR's data library by entering the project title, project year, the name of the country/region/location(s) where the data was collected, the Project Partnership Agreement number (if available), and the name of the focal point in UNHCR."),
+      placeholder="",
+      value=data.message,
+      classes=["control-medium"],
+      error=errors.message,
+      is_required=True
+  ) }}
+
+  {{ form.select(
+    "container",
+    id="field-container",
+    label=_("Please select the region where the data was collected."),
+    options=containers,
+    error=errors.container,
+    selected=data.container,
+    is_required=True,
+  ) }}
+
+  {% if g.recaptcha_publickey %}
+    {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+  {% endif %}
+
+  {{ form.required_message() }}
+
+  <div class="form-actions">
+    {% block form_actions %}
+    <button class="btn btn-primary" type="submit" name="save">{{ _("Request Account") }}</button>
+    {% endblock %}
+  </div>
+</form>

--- a/ckanext/unhcr/templates/user/snippets/access_request_list.html
+++ b/ckanext/unhcr/templates/user/snippets/access_request_list.html
@@ -3,6 +3,7 @@
     <li class="dataset-item">
       <div class="dataset-content">
         <h3>
+          {% if req.object_type == 'user' %}External user{% endif %}
           {{ h.link_to(req.user.fullname or req.user.name, h.url_for('user.read', id=req.user.id, qualified=True)) }}
           {% if req.object_type == 'package' %}
             requested {{ req.role }} access to dataset
@@ -10,6 +11,8 @@
           {% elif req.object_type == 'organization' %}
             requested {{ req.role }} access to container
             {{ h.link_to(req.object.title or req.object.name, h.url_for('data-container_read', id=req.object.name, qualified=True)) }}
+          {% elif req.object_type == 'user' %}
+            requested access to deposit datasets
           {% else %}
             &nbsp;
           {% endif %}

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -769,7 +769,6 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
     def setup(self):
         super(TestAccessRequestUpdate, self).setup()
 
-        self.sysadmin = core_factories.Sysadmin()
         self.requesting_user = core_factories.User()
         self.standard_user = core_factories.User()
         self.pending_user = core_factories.User(
@@ -821,7 +820,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         orgs = toolkit.get_action("organization_list_for_user")(
-            {"user": self.sysadmin["name"]},
+            {"ignore_auth": True},
             {"id": self.requesting_user["name"], "permission": "read"}
         )
         assert_equals(0, len(orgs))
@@ -837,7 +836,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             )
 
             orgs = toolkit.get_action("organization_list_for_user")(
-                {"user": self.sysadmin["name"]},
+                {"ignore_auth": True},
                 {"id": self.requesting_user["name"], "permission": "read"}
             )
             assert_equals(self.container1['id'], orgs[0]['id'])
@@ -864,7 +863,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         orgs = toolkit.get_action("organization_list_for_user")(
-            {"user": self.sysadmin["name"]},
+            {"ignore_auth": True},
             {"id": self.requesting_user["name"], "permission": "read"}
         )
         assert_equals(0, len(orgs))
@@ -878,7 +877,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         orgs = toolkit.get_action("organization_list_for_user")(
-            {"user": self.sysadmin["name"]},
+            {"ignore_auth": True},
             {"id": self.requesting_user["name"], "permission": "read"}
         )
         assert_equals(0, len(orgs))
@@ -894,7 +893,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         collaborators = toolkit.get_action("dataset_collaborator_list")(
-            {"user": self.sysadmin["name"]}, {"id": self.dataset1["id"]}
+            {"ignore_auth": True}, {"id": self.dataset1["id"]}
         )
         assert_equals(0, len(collaborators))
         assert_equals('requested', self.dataset_request.status)
@@ -909,7 +908,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             )
 
             collaborators = toolkit.get_action("dataset_collaborator_list")(
-                {"user": self.sysadmin["name"]}, {"id": self.dataset1["id"]}
+                {"ignore_auth": True}, {"id": self.dataset1["id"]}
             )
             assert_equals(self.requesting_user["id"], collaborators[0]["user_id"])
             assert_equals('approved', self.dataset_request.status)
@@ -930,7 +929,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         collaborators = toolkit.get_action("dataset_collaborator_list")(
-            {"user": self.sysadmin["name"]}, {"id": self.dataset1["id"]}
+            {"ignore_auth": True}, {"id": self.dataset1["id"]}
         )
         assert_equals(0, len(collaborators))
         assert_equals('requested', self.dataset_request.status)
@@ -943,7 +942,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         collaborators = toolkit.get_action("dataset_collaborator_list")(
-            {"user": self.sysadmin["name"]}, {"id": self.dataset1["id"]}
+            {"ignore_auth": True}, {"id": self.dataset1["id"]}
         )
         assert_equals(0, len(collaborators))
         assert_equals('rejected', self.dataset_request.status)
@@ -958,7 +957,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         user = toolkit.get_action("user_show")(
-            {"user": self.sysadmin["name"]}, {"id": self.pending_user["id"]}
+            {"ignore_auth": True}, {"id": self.pending_user["id"]}
         )
         assert_equals(model.State.PENDING, user['state'])
 
@@ -972,7 +971,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             )
 
             user = toolkit.get_action("user_show")(
-                {"user": self.sysadmin["name"]}, {"id": self.pending_user["id"]}
+                {"ignore_auth": True}, {"id": self.pending_user["id"]}
             )
             assert_equals(model.State.ACTIVE, user['state'])
             assert_equals('approved', self.user_request.status)
@@ -1001,7 +1000,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         user = toolkit.get_action("user_show")(
-            {"user": self.sysadmin["name"]}, {"id": self.pending_user["id"]}
+            {"ignore_auth": True}, {"id": self.pending_user["id"]}
         )
         assert_equals(model.State.PENDING, user['state'])
 
@@ -1013,7 +1012,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
 
         user = toolkit.get_action("user_show")(
-            {"user": self.sysadmin["name"]}, {"id": self.pending_user["id"]}
+            {"ignore_auth": True}, {"id": self.pending_user["id"]}
         )
         assert_equals(model.State.DELETED, user['state'])
         assert_equals('rejected', self.user_request.status)

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -1134,7 +1134,19 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
             state=model.State.PENDING,
             email='fred@externaluser.com',
         )
+        access_request_data_dict = {
+            'object_id': target_user['id'],
+            'object_type': 'user',
+            'message': 'asdf',
+            'role': 'member',
+            'data': {'containers': [self.container1['id']]}
+        }
+        toolkit.get_action(u'access_request_create')(
+            {'user': target_user['id'], 'ignore_auth': True},
+            access_request_data_dict
+        )
         requesting_user = core_factories.User()
+
         action = toolkit.get_action("external_user_update_state")
         assert_raises(
             toolkit.NotAuthorized,
@@ -1143,11 +1155,65 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
             {'id': target_user['id'], 'state': model.State.ACTIVE}
         )
 
+    def test_requesting_user_is_not_admin_of_required_container(self):
+        target_user = core_factories.User(
+            state=model.State.PENDING,
+            email='fred@externaluser.com',
+        )
+        requesting_user = core_factories.User()
+        container2 = factories.DataContainer(
+            users=[{"name": requesting_user["name"], "capacity": "admin"}]
+        )
+        access_request_data_dict = {
+            'object_id': target_user['id'],
+            'object_type': 'user',
+            'message': 'asdf',
+            'role': 'member',
+            'data': {'containers': [self.container1['id']]}
+        }
+        toolkit.get_action(u'access_request_create')(
+            {'user': target_user['id'], 'ignore_auth': True},
+            access_request_data_dict
+        )
+
+        action = toolkit.get_action("external_user_update_state")
+        assert_raises(
+            toolkit.NotAuthorized,
+            action,
+            {"user": requesting_user["name"]},
+            {'id': target_user['id'], 'state': model.State.ACTIVE}
+        )
+
+    def test_no_access_request(self):
+        target_user = core_factories.User(
+            state=model.State.PENDING,
+            email='fred@externaluser.com',
+        )
+        action = toolkit.get_action("external_user_update_state")
+        assert_raises(
+            toolkit.NotAuthorized,
+            action,
+            {"user": self.container1_admin["name"]},
+            {'id': target_user['id'], 'state': model.State.ACTIVE}
+        )
+
     def test_invalid_state(self):
         target_user = core_factories.User(
             state=model.State.PENDING,
             email='fred@externaluser.com',
         )
+        access_request_data_dict = {
+            'object_id': target_user['id'],
+            'object_type': 'user',
+            'message': 'asdf',
+            'role': 'member',
+            'data': {'containers': [self.container1['id']]}
+        }
+        toolkit.get_action(u'access_request_create')(
+            {'user': target_user['id'], 'ignore_auth': True},
+            access_request_data_dict
+        )
+
         action = toolkit.get_action("external_user_update_state")
         assert_raises(
             toolkit.ValidationError,
@@ -1170,6 +1236,18 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
             state=model.State.PENDING,
             email='fred@externaluser.com',
         )
+        access_request_data_dict = {
+            'object_id': target_user['id'],
+            'object_type': 'user',
+            'message': 'asdf',
+            'role': 'member',
+            'data': {'containers': [self.container1['id']]}
+        }
+        toolkit.get_action(u'access_request_create')(
+            {'user': target_user['id'], 'ignore_auth': True},
+            access_request_data_dict
+        )
+
         action = toolkit.get_action("external_user_update_state")
         action(
             {"user": self.container1_admin["name"]},

--- a/ckanext/unhcr/tests/test_controllers.py
+++ b/ckanext/unhcr/tests/test_controllers.py
@@ -1909,6 +1909,32 @@ class TestUserRegister(base.FunctionalTestBase):
             {'id': 'externaluser'}
         )
 
+    def test_logged_in(self):
+        user = core_factories.User()
+
+        self.app.get(
+            url_for('user.register'),
+            extra_environ={'REMOTE_USER': user['name'].encode('ascii')},
+            status=403
+        )
+        self.app.get(
+            url_for('user.register'),
+            extra_environ={'REMOTE_USER': self.sysadmin['name'].encode('ascii')},
+            status=403
+        )
+        self.app.post(
+            url_for('user.register'),
+            self.payload,
+            extra_environ={'REMOTE_USER': user['name'].encode('ascii')},
+            status=403
+        )
+        self.app.post(
+            url_for('user.register'),
+            self.payload,
+            extra_environ={'REMOTE_USER': self.sysadmin['name'].encode('ascii')},
+            status=403
+        )
+
 
 class TestMetricsController(base.FunctionalTestBase):
 

--- a/ckanext/unhcr/tests/test_mailer.py
+++ b/ckanext/unhcr/tests/test_mailer.py
@@ -322,7 +322,7 @@ class TestAccessRequestMailer(base.FunctionalTestBase):
         dataset1 = factories.Dataset(title='Test Dataset 1')
 
         message = 'Nope\nNot today thank you'
-        email_body = mailer.compose_request_rejected_email_body(user1, dataset1, message)
+        email_body = mailer.compose_request_rejected_email_body('dataset', user1, dataset1, message)
         regularised_body = regularise_html(email_body)
 
         assert 'Your request to access <strong>Test Dataset 1</strong> has been rejected.' in regularised_body
@@ -333,7 +333,7 @@ class TestAccessRequestMailer(base.FunctionalTestBase):
         container1 = factories.DataContainer(title='Test Organization 1')
 
         message = 'Nope\nNot today thank you'
-        email_body = mailer.compose_request_rejected_email_body(user1, container1, message)
+        email_body = mailer.compose_request_rejected_email_body('container', user1, container1, message)
         regularised_body = regularise_html(email_body)
 
         assert 'Your request to access <strong>Test Organization 1</strong> has been rejected.' in regularised_body

--- a/ckanext/unhcr/tests/test_mailer.py
+++ b/ckanext/unhcr/tests/test_mailer.py
@@ -271,6 +271,23 @@ class TestAccessRequestMailer(base.FunctionalTestBase):
         assert expected in regularised_body
         assert '<p>I can haz access?<br> kthxbye</p>' in regularised_body
 
+    def test_user_request_access_body(self):
+        user1 = core_factories.User(name='user1', id='user1')
+
+        user_message = 'I can haz access?\nkthxbye'
+        email_body = mailer.compose_request_access_email_body(
+            'user', self.sysadmin, user1, user1, user_message
+        )
+        regularised_body = regularise_html(email_body)
+        expected = regularise_html(
+            'External user <a href="{user_link}">Mr. Test User</a> has requested access to deposit datasets.'.format(
+                user_link=toolkit.url_for('user.read', id=user1['id'], qualified=True),
+            )
+        )
+
+        assert expected in regularised_body
+        assert '<p>I can haz access?<br> kthxbye</p>' in regularised_body
+
     def test_recipients_with_org_admins(self):
         editor = core_factories.User()
         admin = core_factories.User()
@@ -338,3 +355,76 @@ class TestAccessRequestMailer(base.FunctionalTestBase):
 
         assert 'Your request to access <strong>Test Organization 1</strong> has been rejected.' in regularised_body
         assert '<p>Nope<br> Not today thank you</p>' in regularised_body
+
+    def test_request_rejected_email_body_user(self):
+        user1 = core_factories.User(name='user1', id='user1')
+
+        message = 'Nope\nNot today thank you'
+        email_body = mailer.compose_request_rejected_email_body('user', user1, user1, message)
+        regularised_body = regularise_html(email_body)
+
+        assert 'Your request for a RIDL user account has been rejected.' in regularised_body
+        assert '<p>Nope<br> Not today thank you</p>' in regularised_body
+
+    def test_account_approved_email_body(self):
+        user1 = core_factories.User(name='user1', id='user1')
+        email_body = mailer.compose_account_approved_email_body(user1)
+        regularised_body = regularise_html(email_body)
+
+        assert 'Your request for a RIDL user account has been approved by an administrator.' in regularised_body
+
+    def test_get_user_account_request_access_email_recipients(self):
+        users = [
+            core_factories.User(),
+            core_factories.User(),
+            core_factories.User(),
+            core_factories.User(),
+        ]
+        containers = [
+            factories.DataContainer(
+                users=[
+                    {'name': users[0]['name'], 'capacity': 'admin'},
+                    {'name': users[1]['name'], 'capacity': 'admin'},
+                    {'name': users[2]['name'], 'capacity': 'editor'},
+                ]
+            ),
+            factories.DataContainer(
+                users=[
+                    {'name': users[0]['name'], 'capacity': 'admin'},
+                    {'name': users[2]['name'], 'capacity': 'editor'},
+                ]
+            ),
+            factories.DataContainer(
+                users=[
+                    {'name': users[0]['name'], 'capacity': 'admin'},
+                ]
+            ),
+            factories.DataContainer(
+                users=[
+                    {'name': users[3]['name'], 'capacity': 'admin'},
+                ]
+            ),
+        ]
+        recipients = mailer.get_user_account_request_access_email_recipients([
+            containers[0]['id'], containers[1]['id'], containers[2]['id']
+        ])
+
+        recipient_ids = [r['id'] for r in recipients]
+
+        assert len(recipient_ids) == 3
+
+        # no duplicates
+        assert len(recipient_ids) == len(list(set(recipient_ids)))
+
+        # users[0] and users[1] are admins of >=1 container
+        assert users[0]['id'] in recipient_ids
+        assert users[1]['id'] in recipient_ids
+
+        # users[2] isn't an admin of any container
+        assert users[2]['id'] not in recipient_ids
+
+        # users[3] isn't an admin of any container we specified
+        assert users[2]['id'] not in recipient_ids
+
+        # we should always mail sysadmin
+        assert self.sysadmin['id'] in recipient_ids

--- a/ckanext/unhcr/utils.py
+++ b/ckanext/unhcr/utils.py
@@ -1,6 +1,15 @@
+import ckan.plugins.toolkit as toolkit
 # TODO: move here helpers not used in templates?
 
-# Misc
+
+INTERNAL_DOMAINS = ['unhcr.org']
+
+def get_internal_domains():
+    return toolkit.aslist(
+        toolkit.config.get('ckanext.unhcr.internal_domains', INTERNAL_DOMAINS),
+        sep = ','
+    )
+
 
 def normalize_list(value):
     if isinstance(value, list):


### PR DESCRIPTION
Refs #378
Refs https://github.com/okfn/docker-ckan-unhcr-aws/pull/15

**Progress:**

- [x] Create customised `RegisterView`
- [x] Don't allow internal users to create an external user account
- [x] Create new users with pending status ( `ckan.model.State.PENDING` )
- [x] Drop new users to a confirmation/pending approval page after signup. Don't try to log them in
- [x] Collect 2 extra fields on signup:
    - Free text box: who are you/why do you want an account?
    - Containers: pick a/some containers relevant to your work
- [x] Better text/copy (in progress: following up with client)
    - What are we calling external accounts?
    - Better labels for message/container fields
    - What's the CTA for internal users trying to create an external account?
    - Sidebar content, some kind of explanation of what this is (it will be the first page a new external user sees)
- [x] Use message/containers to notify appropriate container admins to approve the request
- [ ] Enable Captcha (CKAN core already suports this - think we just need to set `ckan.recaptcha.publickey` and `ckan.recaptcha.privatekey`: https://docs.ckan.org/en/2.8/maintaining/configuration.html?highlight=recaptcha#ckan-recaptcha-publickey ) - TODO: deploy repo
- [x] Interface to allow admin users to approve/reject account requests, confirmation email template
    - [x] Add a user value to the object enum + migration
    - [x] Add an optional data:JSONB column + migration
    - [x] Modify `RegisterView.post()` to create an access request with `access_request_create`
    - [x] Surface user AccessRequests through the front-end ( `ExtendedUser.list_requests` / `dashboard_requests.html` )
    - [x] Modify `access_request_update` action/auth functions so we can approve/reject user account requests
        - approve moves the status from pending to active
        - reject moves the status from pending to deleted
    - [x] Emails for approved/rejected requests
    - [x] Automated test for all that
- [x] Automated tests (the CKAN core tests for `RegisterView` will be a good start for some of this as the new `RegisterView` replicates a lot of core functionality) but there will be more to do. So far I have writen zero tests
- [x] What should the behaviour be if you hit `/user/register` and you're already logged in?