### PR TITLE
clearly indicate when users are external/pending on `/user` and `/user/<id>`

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -928,3 +928,28 @@ def user_autocomplete(context, data_dict):
         user_list.append(result_dict)
 
     return user_list
+
+
+@toolkit.chained_action
+def user_list(up_func, context, data_dict):
+    users = up_func(context, data_dict)
+    m = context.get('model', model)
+
+    if type(users[0]) == dict:
+        users_db = (
+            m.Session.query(m.User)
+            .filter(m.User.id.in_([u['id'] for u in users]))
+            .all()
+        )
+        id_to_external = {u.id: u.external for u in users_db}
+        for user in users:
+            user['external'] = id_to_external[user['id']]
+
+    return users
+
+
+@toolkit.chained_action
+def user_show(up_func, context, data_dict):
+    user = up_func(context, data_dict)
+    user['external'] = context['user_obj'].external
+    return user

--- a/ckanext/unhcr/controllers/data_container.py
+++ b/ckanext/unhcr/controllers/data_container.py
@@ -4,7 +4,7 @@ import ckan.plugins.toolkit as toolkit
 import ckan.logic.action.get as get_core
 import ckan.logic.action.patch as patch_core
 import ckan.logic.action.delete as delete_core
-from ckanext.unhcr import helpers, mailer, utils
+from ckanext.unhcr import helpers, mailer
 log = logging.getLogger(__name__)
 
 
@@ -71,7 +71,7 @@ class DataContainerController(toolkit.BaseController):
         # Get users
         users = toolkit.get_action('user_list')(
             context, {'order_by': 'display_name'})
-        users = [u for u in users if not utils.user_is_external(u)]
+        users = [u for u in users if not u['external']]
 
         # Get user
         user = None

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -181,10 +181,6 @@ def user_is_curator():
     return user_id in user_ids
 
 
-def user_is_external(user):
-    return utils.user_is_external(user)
-
-
 def user_is_container_admin(user=None):
     if not user:
         user = toolkit.c.user

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -284,7 +284,6 @@ class UnhcrPlugin(
             'page_authorized': helpers.page_authorized,
             'get_came_from_param': helpers.get_came_from_param,
             'user_is_curator': helpers.user_is_curator,
-            'user_is_external': helpers.user_is_external,
             'user_is_container_admin': helpers.user_is_container_admin,
             # Linked datasets
             'get_linked_datasets_for_form': helpers.get_linked_datasets_for_form,
@@ -514,6 +513,8 @@ class UnhcrPlugin(
             'external_user_update_state': actions.external_user_update_state,
             'search_index_rebuild': actions.search_index_rebuild,
             'user_autocomplete': actions.user_autocomplete,
+            'user_list': actions.user_list,
+            'user_show': actions.user_show,
         }
 
     # IValidators

--- a/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
+++ b/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
@@ -107,7 +107,7 @@
             class="label label-warning"
             title="This dataset was submitted by a user outside of UNHCR"
           >
-            external
+            External
           </span>
         {% endif %}
         </dd>

--- a/ckanext/unhcr/templates/snippets/deposit_package_item.html
+++ b/ckanext/unhcr/templates/snippets/deposit_package_item.html
@@ -88,7 +88,7 @@
                         class="label label-warning"
                         title="This dataset was submitted by a user outside of UNHCR"
                       >
-                        external
+                        External
                       </span>
                     {% endif %}
                   </dd>

--- a/ckanext/unhcr/templates/user/list.html
+++ b/ckanext/unhcr/templates/user/list.html
@@ -10,8 +10,8 @@
   {% for user in page.items %}
     <tr>
       <td>{{ h.linked_user(user['name'], maxlength=20) }}</td>
-      <td>{% if h.user_is_external(user.User) %}external{% else %}UNHCR{% endif %}</td>
-      <td>{{ user.User.state }}</td>
+      <td>{% if h.user_is_external(user.User) %}External{% else %}UNHCR{% endif %}</td>
+      <td>{{ user.User.state.capitalize() }}</td>
     </tr>
   {% endfor %}
 </table>

--- a/ckanext/unhcr/templates/user/list.html
+++ b/ckanext/unhcr/templates/user/list.html
@@ -1,0 +1,18 @@
+{% ckan_extends %}
+
+{% block users_list %}
+<table class="table table-header table-hover table-bordered">
+  <tr>
+    <th>Username</th>
+    <th>Organisation</th>
+    <th>State</th>
+  </tr>
+  {% for user in page.items %}
+    <tr>
+      <td>{{ h.linked_user(user['name'], maxlength=20) }}</td>
+      <td>{% if h.user_is_external(user.User) %}external{% else %}UNHCR{% endif %}</td>
+      <td>{{ user.User.state }}</td>
+    </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/ckanext/unhcr/templates/user/list.html
+++ b/ckanext/unhcr/templates/user/list.html
@@ -10,7 +10,7 @@
   {% for user in page.items %}
     <tr>
       <td>{{ h.linked_user(user['name'], maxlength=20) }}</td>
-      <td>{% if h.user_is_external(user.User) %}External{% else %}UNHCR{% endif %}</td>
+      <td>{% if user.User.external %}External{% else %}UNHCR{% endif %}</td>
       <td>{{ user.User.state.capitalize() }}</td>
     </tr>
   {% endfor %}

--- a/ckanext/unhcr/templates/user/read_base.html
+++ b/ckanext/unhcr/templates/user/read_base.html
@@ -1,0 +1,60 @@
+{% ckan_extends %}
+
+{% block user_info %}
+<div class="info">
+  <dl>
+    {% if user.name.startswith('http://') or user.name.startswith('https://') %}
+      <dt>{{ _('Open ID') }}</dt>
+      <dd>{{ user.name|urlize(25) }}{# Be great if this just showed the domain #}</dd>
+    {% else %}
+      <dt>{{ _('Username') }}</dt>
+      <dd>{{ user.name }}</dd>
+    {% endif %}
+  </dl>
+  {% if is_myself %}
+    <dl>
+      <dt>
+        {{ _('Email') }}
+        <span class="label label-default" title="{{ _('This means only you can see this') }}">
+          {{ _('Private') }}
+        </span>
+      </dt>
+      <dd>{{ user.email }}</dd>
+    </dl>
+  {% endif %}
+  <dl>
+    <dt>{{ _('Member Since') }}</dt>
+    <dd>{{ h.render_datetime(user.created) }}</dd>
+  </dl>
+  <dl>
+    <dt>{{ _('Organisation') }}</dt>
+    <dd>
+      {% if h.user_is_external(user) %}
+        <span class="label label-warning">external</span>
+      {% else %}
+        UNHCR
+      {% endif %}</dd>
+  </dl>
+  <dl>
+    <dt>{{ _('State') }}</dt>
+    <dd>
+      {% if user.state != 'active' %}
+        <span class="label label-warning">{{ user.state }}</span>
+      {% else %}
+        {{ user.state }}
+      {% endif %}
+    </dd>
+  </dl>
+  {% if is_myself %}
+    <dl>
+      <dt class="key">
+        {{ _('API Key') }}
+        <span class="label label-default" title="{{ _('This means only you can see this') }}">
+          {{ _('Private') }}
+        </span>
+      </dt>
+      <dd class="value"><code>{{ user.apikey }}</code></dd>
+    </dl>
+  {% endif %}
+</div>
+{% endblock %}

--- a/ckanext/unhcr/templates/user/read_base.html
+++ b/ckanext/unhcr/templates/user/read_base.html
@@ -29,7 +29,7 @@
   <dl>
     <dt>{{ _('Organisation') }}</dt>
     <dd>
-      {% if h.user_is_external(user) %}
+      {% if user.external %}
         <span class="label label-warning">External</span>
       {% else %}
         UNHCR

--- a/ckanext/unhcr/templates/user/read_base.html
+++ b/ckanext/unhcr/templates/user/read_base.html
@@ -30,7 +30,7 @@
     <dt>{{ _('Organisation') }}</dt>
     <dd>
       {% if h.user_is_external(user) %}
-        <span class="label label-warning">external</span>
+        <span class="label label-warning">External</span>
       {% else %}
         UNHCR
       {% endif %}</dd>
@@ -39,9 +39,9 @@
     <dt>{{ _('State') }}</dt>
     <dd>
       {% if user.state != 'active' %}
-        <span class="label label-warning">{{ user.state }}</span>
+        <span class="label label-warning">{{ user.state.capitalize() }}</span>
       {% else %}
-        {{ user.state }}
+        {{ user.state.capitalize() }}
       {% endif %}
     </dd>
   </dl>

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -4,7 +4,7 @@ import responses
 from ckan import model
 from ckan.plugins import toolkit
 from ckan.tests import helpers as core_helpers, factories as core_factories
-from nose.tools import assert_raises, assert_equals, nottest
+from nose.tools import assert_raises, assert_equals, assert_true, assert_false, nottest
 from ckanext.unhcr.models import AccessRequest
 from ckanext.unhcr.tests import base, factories, mocks
 from ckanext.unhcr import helpers
@@ -1384,3 +1384,26 @@ class TestUserAutocomplete(base.FunctionalTestBase):
 
         result = action(context, {'q': 'foobar'})
         assert_equals(0, len(result))
+
+
+class TestUserActions(base.FunctionalTestBase):
+    def test_user_list(self):
+        sysadmin = core_factories.Sysadmin()
+        external_user = core_factories.User(email='fred@externaluser.com')
+        internal_user = core_factories.User()
+
+        action = toolkit.get_action('user_list')
+        context = {'user': sysadmin['name']}
+        users = action(context, {})
+        assert_equals(1, len([u for u in users if u['external']]))
+        assert_equals(2, len([u for u in users if not u['external']]))
+
+    def test_user_show(self):
+        sysadmin = core_factories.Sysadmin()
+        external_user = core_factories.User(email='fred@externaluser.com')
+        internal_user = core_factories.User()
+
+        action = toolkit.get_action('user_show')
+        context = {'user': sysadmin['name']}
+        assert_true(action(context, {'id': external_user['id']})['external'])
+        assert_false(action(context, {'id': internal_user['id']})['external'])

--- a/ckanext/unhcr/utils.py
+++ b/ckanext/unhcr/utils.py
@@ -35,34 +35,17 @@ def get_module_functions(module_path):
     return module_functions
 
 
-
 def user_is_external(user):
     '''
     Returns True if user email is not in the managed internal domains.
     '''
-
     try:
-        email = user.email
-        sysadmin = user.sysadmin
-    except AttributeError:
-        try:
-            email = user['email']
-            sysadmin = user['sysadmin']
-        except KeyError:
-            raise toolkit.Invalid('not a user object')
-
-    try:
-        domain = email.split('@')[1]
+        domain = user.email.split('@')[1]
     except AttributeError:
          # Internal sysadmin user does not have email
-        if sysadmin:
+        if user.sysadmin:
             return False
         else:
             return True
-
-    internal_domains = toolkit.aslist(
-        toolkit.config.get('ckanext.unhcr.internal_domains', INTERNAL_DOMAINS),
-        sep = ','
-    )
 
     return domain not in get_internal_domains()


### PR DESCRIPTION
Closes #412
This has a bit of a merge conflict with #414 so lets work on getting that one merged first and I'll rebase this.