### PR TITLE
Allow container admins to review deposits for their own container

### DIFF
--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -228,9 +228,9 @@ def resource_download(context, data_dict):
     user_id = getattr(context.get('auth_user_obj'), 'id', None)
     is_deposit = dataset.get('type') == 'deposited-dataset'
     if is_deposit:
-        is_depositor = is_deposit and dataset.get('creator_user_id') == user_id
+        is_depositor = dataset.get('creator_user_id') == user_id
         curators = [u['id'] for u in helpers.get_data_curation_users(dataset)]
-        is_curator = is_deposit and user_id in curators
+        is_curator = user_id in curators
     else:
         is_depositor = False
         is_curator = False

--- a/ckanext/unhcr/controllers/deposited_dataset.py
+++ b/ckanext/unhcr/controllers/deposited_dataset.py
@@ -280,7 +280,7 @@ class DepositedDatasetController(toolkit.BaseController):
         message = toolkit.request.params.get('message')
         curator = curation['contacts']['curator']
         # We don't bother all curators if someone is already assigned
-        users = [curator] if curator else helpers.get_data_curation_users()
+        users = [curator] if curator else helpers.get_data_curation_users(dataset)
         for user in users:
             subj = mailer.compose_curation_email_subj(dataset)
             body = mailer.compose_curation_email_body(
@@ -321,7 +321,7 @@ class DepositedDatasetController(toolkit.BaseController):
 
         # Send notification email
         message = toolkit.request.params.get('message')
-        for user in helpers.get_data_curation_users():
+        for user in helpers.get_data_curation_users(dataset):
             subj = mailer.compose_curation_email_subj(dataset)
             body = mailer.compose_curation_email_body(
                 dataset, curation, user['display_name'], 'withdraw', message=message)

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -289,7 +289,7 @@ def get_existing_access_request(user_id, object_id, status):
 cached_deposit = None
 def get_data_deposit():
     '''
-    Return the dict of the underlyig organization for the data deposit
+    Return the dict of the underlying organization for the data deposit
 
     This function uses a cache so it's OK to call it multiple times
 

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -543,10 +543,21 @@ class UnhcrPlugin(
 
         # For deposited datasets
         if dataset_obj.type == 'deposited-dataset':
+            context = {'ignore_auth': True}
+            dataset = toolkit.get_action('package_show')(
+                context,
+                {'id': dataset_obj.id}
+            )
+            deposit = helpers.get_data_deposit()
+
             labels = [
                 'deposited-dataset',
                 'creator-%s' % dataset_obj.creator_user_id,
             ]
+            if dataset['owner_org_dest'] not in [deposit['id'], 'unknown']:
+                labels.append(
+                    'deposited-dataset-{}'.format(dataset['owner_org_dest'])
+                )
 
         # For normal datasets
         else:
@@ -573,7 +584,12 @@ class UnhcrPlugin(
             orgs = toolkit.get_action('organization_list_for_user')(context, {})
             for org in orgs:
                 if deposit['id'] == org['id']:
-                    labels.extend(['deposited-dataset'])
+                    labels.append('deposited-dataset')
+                    continue
+                if org['capacity'] == 'admin':
+                    labels.append(
+                        'deposited-dataset-{}'.format(org['id'])
+                    )
 
         return labels
 

--- a/ckanext/unhcr/templates/organization/snippets/curation_sidebar.html
+++ b/ckanext/unhcr/templates/organization/snippets/curation_sidebar.html
@@ -30,7 +30,7 @@
         {% trans %}Deposit Dataset{% endtrans %}
       </a>
 
-      {% if curation_role in ['admin', 'curator'] %}
+      {% if curation_role in ['admin', 'curator', 'container admin'] %}
         {% if not editing %}
           <a href="/data-container/{{ deposit.name }}?curator_display_name={{ c.userobj.display_name }}" role="button" class="btn btn-warning">
             {% trans %}Show Assigned To Me{% endtrans %}

--- a/ckanext/unhcr/templates/package/snippets/curation_modals.html
+++ b/ckanext/unhcr/templates/package/snippets/curation_modals.html
@@ -72,7 +72,7 @@
           <div class="control-group control-select">
             <div class="controls ">
               <select id="curator_id" name="curator_id">
-                {% set curators = h.get_data_curation_users() %}
+                {% set curators = h.get_data_curation_users(pkg) %}
                 {% set selected = pkg.curator_id not in curators|map(attribute='id') %}
                 <option value="" {% if selected %}selected{% endif %}>
                   Not Assigned {% if selected %}(current){% endif %}

--- a/ckanext/unhcr/tests/test_auth.py
+++ b/ckanext/unhcr/tests/test_auth.py
@@ -251,7 +251,7 @@ class TestAuthUnit(base.FunctionalTestBase):
     def test_resource_download(self):
         container_member = core_factories.User()
         dataset_member = core_factories.User()
-        external_user = core_factories.User()
+        another_user = core_factories.User()
         data_container = factories.DataContainer(
             users=[{'name': container_member['name'], 'capacity': 'admin'}]
         )
@@ -278,8 +278,55 @@ class TestAuthUnit(base.FunctionalTestBase):
 
         assert_equals(
             {'success': False},
-            auth.resource_download({'user': external_user['name']}, resource)
+            auth.resource_download({'user': another_user['name']}, resource)
         )
+
+    def test_resource_download_deposited_dataset(self):
+        depadmin = core_factories.User()
+        curator = core_factories.User()
+        target_container_admin = core_factories.User()
+        target_container_member = core_factories.User()
+        other_container_admin = core_factories.User()
+
+        deposit = factories.DataContainer(
+            id='data-deposit',
+            users=[
+                {'name': depadmin['name'], 'capacity': 'admin'},
+                {'name': curator['name'], 'capacity': 'editor'},
+            ]
+        )
+        target = factories.DataContainer(
+            users=[
+                {'name': target_container_admin['name'], 'capacity': 'admin'},
+                {'name': target_container_member['name'], 'capacity': 'member'},
+            ]
+        )
+        container = factories.DataContainer(
+            users=[
+                {'name': other_container_admin['name'], 'capacity': 'admin'},
+            ]
+        )
+
+        dataset = factories.DepositedDataset(
+            owner_org=deposit['id'],
+            owner_org_dest=target['id']
+        )
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            url_type='upload',
+        )
+
+        for user in [depadmin, curator, target_container_admin]:
+            assert_equals(
+                {'success': True},
+                auth.resource_download({'user': user['name']}, resource)
+            )
+
+        for user in [target_container_member, other_container_admin]:
+            assert_equals(
+                {'success': False},
+                auth.resource_download({'user': user['name']}, resource)
+            )
 
     def test_external_users_core_actions(self):
         external_user = core_factories.User(email='fred@externaluser.com')

--- a/ckanext/unhcr/tests/test_validators.py
+++ b/ckanext/unhcr/tests/test_validators.py
@@ -93,9 +93,6 @@ class TestValidators(base.FunctionalTestBase):
         assert_raises(toolkit.Invalid,
             validators.deposited_dataset_curation_state, 'invalid', {})
 
-    def test_deposited_dataset_curation_id_invalid(self):
-        assert_raises(toolkit.Invalid,
-            validators.deposited_dataset_curator_id, 'invalid', {})
 
     # Private datasets
 
@@ -292,3 +289,100 @@ class TestValidators(base.FunctionalTestBase):
                 {},
                 context,
             )
+
+
+class TestDepositedDatasetCurationId(base.FunctionalTestBase):
+
+    def setup(self):
+        super(TestDepositedDatasetCurationId, self).setup()
+
+        self.depadmin = core_factories.User()
+        self.curator = core_factories.User()
+        self.target_container_admin = core_factories.User()
+        self.target_container_member = core_factories.User()
+        self.other_container_admin = core_factories.User()
+
+        deposit = factories.DataContainer(
+            id='data-deposit',
+            users=[
+                {'name': self.depadmin['name'], 'capacity': 'admin'},
+                {'name': self.curator['name'], 'capacity': 'editor'},
+            ]
+        )
+        target = factories.DataContainer(
+            users=[
+                {'name': self.target_container_admin['name'], 'capacity': 'admin'},
+                {'name': self.target_container_member['name'], 'capacity': 'member'},
+            ]
+        )
+        container = factories.DataContainer(
+            users=[
+                {'name': self.other_container_admin['name'], 'capacity': 'admin'},
+            ]
+        )
+
+        dataset = factories.DepositedDataset(
+            owner_org=deposit['id'],
+            owner_org_dest=target['id']
+        )
+        self.package = model.Package.get(dataset['id'])
+
+    def test_deposited_dataset_curation_id_no_package_in_context_valid(self):
+        assert_equals(
+            self.depadmin['name'],
+            validators.deposited_dataset_curator_id(self.depadmin['name'], {})
+        )
+        assert_equals(
+            self.curator['name'],
+            validators.deposited_dataset_curator_id(self.curator['name'], {})
+        )
+
+    def test_deposited_dataset_curation_id_no_package_in_context_invalid(self):
+        assert_raises(
+            toolkit.Invalid,
+            validators.deposited_dataset_curator_id,
+            self.target_container_admin['name'],
+            {},
+        )
+        assert_raises(
+            toolkit.Invalid,
+            validators.deposited_dataset_curator_id,
+            self.target_container_member['name'],
+            {},
+        )
+        assert_raises(
+            toolkit.Invalid,
+            validators.deposited_dataset_curator_id,
+            self.other_container_admin['name'],
+            {},
+        )
+
+    def test_deposited_dataset_curation_id_with_package_in_context_valid(self):
+        context = {'package': self.package, 'user': self.depadmin['name']}
+        assert_equals(
+            self.depadmin['name'],
+            validators.deposited_dataset_curator_id(self.depadmin['name'], context)
+        )
+        assert_equals(
+            self.curator['name'],
+            validators.deposited_dataset_curator_id(self.curator['name'], context)
+        )
+        assert_equals(
+            self.target_container_admin['name'],
+            validators.deposited_dataset_curator_id(self.target_container_admin['name'], context)
+        )
+
+    def test_deposited_dataset_curation_id_with_package_in_context_invalid(self):
+        context = {'package': self.package, 'user': self.depadmin['name']}
+        assert_raises(
+            toolkit.Invalid,
+            validators.deposited_dataset_curator_id,
+            self.target_container_member['name'],
+            context,
+        )
+        assert_raises(
+            toolkit.Invalid,
+            validators.deposited_dataset_curator_id,
+            self.other_container_admin['name'],
+            context,
+        )

--- a/ckanext/unhcr/validators.py
+++ b/ckanext/unhcr/validators.py
@@ -139,10 +139,19 @@ def deposited_dataset_curation_state(value, context):
 
 def deposited_dataset_curator_id(value, context):
 
+    dataset = None
+    allowed_roles = ['admin', 'curator']
+    if context.get('package'):
+        dataset = toolkit.get_action('package_show')(
+            context,
+            {'id': context['package'].id}
+        )
+        allowed_roles.append('container admin')
+
     # Get curation role and raise if not curator
     if value:
-        curation_role = helpers.get_deposited_dataset_user_curation_role(value)
-        if curation_role not in ['admin', 'curator']:
+        curation_role = helpers.get_deposited_dataset_user_curation_role(value, dataset)
+        if curation_role not in allowed_roles:
             raise Invalid('Invalid Curator id')
 
     return value


### PR DESCRIPTION
Closes #381

This PR adds the ability for container admins to see and review/approve data deposits where the target container is the container they are an admin of.
In terms of the business requirements for this, we agreed that this change behaviour applies to all deposited datasets, so container admins gain the ability to interact with deposited datasets submitted by all users (both UNHCR staff and external users).
