### PR TITLE
fix editing target containers

### DIFF
--- a/ckanext/unhcr/templates/organization/snippets/curation_modals.html
+++ b/ckanext/unhcr/templates/organization/snippets/curation_modals.html
@@ -23,12 +23,7 @@
           <label for="field-owner_org_dest" class="control-label">Destination Data Container</label>
           <div class="controls">
             <select id="field-owner_org_dest" name="owner_org_dest">
-              {% set orgs = h.get_all_data_containers(
-                  exclude_ids=[deposit.id],
-                  include_unknown=True,
-                  external_user=c.userobj.external
-                )
-              %}
+              {% set orgs = h.get_all_data_containers(exclude_ids=[deposit.id], include_unknown=True) %}
               {% for org in orgs %}
                 <option value="{{ org.id }}">{{ org.title }}</option>
               {% endfor %}

--- a/ckanext/unhcr/templates/scheming/form_snippets/owner_org_dest.html
+++ b/ckanext/unhcr/templates/scheming/form_snippets/owner_org_dest.html
@@ -42,7 +42,13 @@
 
   {% set deposit = h.get_data_deposit() %}
 
-  {% set organizations_available=h.get_all_data_containers(exclude_ids=[deposit.id], include_unknown=True) %}
+  {%
+    set organizations_available=h.get_all_data_containers(
+      exclude_ids=[deposit.id],
+      include_ids=[data.owner_org_dest],
+      include_unknown=True
+    )
+  %}
   {% set org_required=not h.check_config_permission('create_unowned_dataset') or h.scheming_field_required(field) %}
 
   {% call _organization() %}

--- a/ckanext/unhcr/tests/test_validators.py
+++ b/ckanext/unhcr/tests/test_validators.py
@@ -50,20 +50,23 @@ class TestValidators(base.FunctionalTestBase):
     def test_deposited_dataset_owner_org_dest(self):
         deposit = factories.DataContainer(id='data-deposit')
         target = factories.DataContainer(id='data-target')
-        result = validators.deposited_dataset_owner_org_dest('data-target', {})
+        user = core_factories.User()
+        result = validators.deposited_dataset_owner_org_dest('data-target', {'user': user['name']})
         assert_equals(result, 'data-target')
 
     def test_deposited_dataset_owner_org_dest_invalid_data_deposit(self):
         deposit = factories.DataContainer(id='data-deposit')
         target = factories.DataContainer(id='data-target')
+        user = core_factories.User()
         assert_raises(toolkit.Invalid,
-            validators.deposited_dataset_owner_org_dest, 'data-deposit', {})
+            validators.deposited_dataset_owner_org_dest, 'data-deposit', {'user': user['name']})
 
     def test_deposited_dataset_owner_org_dest_invalid_not_existent(self):
         deposit = factories.DataContainer(id='data-deposit')
         target = factories.DataContainer(id='data-target')
+        user = core_factories.User()
         assert_raises(toolkit.Invalid,
-            validators.deposited_dataset_owner_org_dest, 'not-existent', {})
+            validators.deposited_dataset_owner_org_dest, 'not-existent', {'user': user['name']})
 
     def test_deposited_dataset_owner_org_dest_not_visible_external(self):
         deposit = factories.DataContainer(id='data-deposit')

--- a/ckanext/unhcr/validators.py
+++ b/ckanext/unhcr/validators.py
@@ -102,19 +102,22 @@ def deposited_dataset_owner_org(value, context):
 
 def deposited_dataset_owner_org_dest(value, context):
     user = context.get('user')
-
     userobj = model.User.get(user)
-    if not userobj:
-        external = True
-    else:
-        external = userobj.external
+
+    include_ids = []
+    package = context.get('package')
+    if package:
+        # 'Package' object has no attribute 'owner_org_dest'
+        dataset = toolkit.get_action('package_show')(context, {'id': package.id})
+        include_ids = [dataset['owner_org_dest']]
 
     # Pass validation if data container exists and NOT for depositing
     deposit = helpers.get_data_deposit()
     orgs = helpers.get_all_data_containers(
         exclude_ids=[deposit['id']],
         include_unknown=True,
-        external_user=external
+        userobj=userobj,
+        include_ids=include_ids,
     )
     for org in orgs:
         if value == org['id']:


### PR DESCRIPTION
Refs #423

This makes most of the improvements noted under #423 :


- External users can only initially target at data container with the `visible_external` flag
- Internal users can initially target at any data container
- When an internal curator user edits a deposit from an external user, they can re-target it at containers without the `visible_external` flag
- If the external user edits it again after that has happened, this doesn't break their ability to edit it/change the target container (the external user can still save the deposited dataset back to the internal container)

so for example, if an external user submits a dataset targetted at Americas then an internal admin changes that to Argentina but bounces it back to the external user for changes, the internal user can still save it back to Argentina (even though they wouldn't have normally been able to target a deposit at Argentina - only the top-level containers) .

![Screenshot at 2020-10-19 15-18-50](https://user-images.githubusercontent.com/6025893/96478810-09f95f00-1230-11eb-8366-2b1fbf7eef1a.png)


The thing I haven't looked at yet is:

- If a container admin edits a dataset from an external user, they should only be able to re-target it at sub-containers of their own container

partly because it depends on #422 so we need to get that reviewed first, but also maybe we can do without that point for the pilot. Lets discuss when we talk this week.