### PR TITLE
rebrand 'external account' as 'partner account'

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -170,7 +170,7 @@ def dataset_collaborator_create(up_func, context, data_dict):
         raise toolkit.ObjectNotFound("User not found")
 
     if user.external:
-        message = 'External users can not be a dataset collaborator'
+        message = 'Partner users can not be a dataset collaborator'
         raise toolkit.ValidationError({'message': message}, error_summary=message)
 
     return up_func(context, data_dict)
@@ -226,7 +226,7 @@ def organization_member_create(context, data_dict):
         raise toolkit.ObjectNotFound("User not found")
 
     if user.external:
-        message = 'External users can not be an organisation member'
+        message = 'Partner users can not be an organisation member'
         raise toolkit.ValidationError({'message': message}, error_summary=message)
 
     if not data_dict.get('not_notify'):

--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -95,7 +95,7 @@ class RegisterView(BaseRegisterView):
 
         if domain in get_internal_domains():
             message = (
-                'Users with an @{domain} email may not register for an external account. '.format(
+                'Users with an @{domain} email may not register for a partner account. '.format(
                     domain=domain
                 ) + 'Log in to {site} using {email} and use your Active Directory password to access RIDL'.format(
                     site=toolkit.config.get('ckan.site_url'),

--- a/ckanext/unhcr/schemas/data_container.json
+++ b/ckanext/unhcr/schemas/data_container.json
@@ -1171,7 +1171,7 @@
         },
         {
             "field_name": "visible_external",
-            "label": "Visible to External users",
+            "label": "Visible to Partner users",
             "required": true,
             "validators": "boolean_validator",
             "output_validators": "boolean_validator",

--- a/ckanext/unhcr/templates/login_form.html
+++ b/ckanext/unhcr/templates/login_form.html
@@ -15,13 +15,13 @@
     <p>
       <a class="btn btn-inverse btn-lg"
         href="/service/login"
-        title="Log in using an external user accout. If you don't have one, you can request one following the link below">
-        Log in as External user
+        title="Log in using a partner user accout. If you don't have one, you can request one following the link below">
+        Log in with a Partner account
       </a>
     </p>
     <p>
       <a class="request" href="{{ h.url_for('user.register') }}">
-        Request an External account
+        Request an Partner account
       </a>
     </p>
   </div>

--- a/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
+++ b/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
@@ -107,7 +107,7 @@
             class="label label-warning"
             title="This dataset was submitted by a user outside of UNHCR"
           >
-            External
+            Partner
           </span>
         {% endif %}
         </dd>

--- a/ckanext/unhcr/templates/scheming/form_snippets/visible_external.html
+++ b/ckanext/unhcr/templates/scheming/form_snippets/visible_external.html
@@ -1,5 +1,5 @@
 <div class="form-group control-ful">
-  <label for="field-visible_external" class="control-label">Visible to External users</label>
+  <label for="field-visible_external" class="control-label">Visible to Partner users</label>
   <div class="controls">
     <select id="field-visible_external" name="visible_external"  class="form-control">
       <option value="true" {% if data.visible_external %}selected="selected"{% endif %}>Yes</option>

--- a/ckanext/unhcr/templates/snippets/deposit_package_item.html
+++ b/ckanext/unhcr/templates/snippets/deposit_package_item.html
@@ -88,7 +88,7 @@
                         class="label label-warning"
                         title="This dataset was submitted by a user outside of UNHCR"
                       >
-                        External
+                        Partner
                       </span>
                     {% endif %}
                   </dd>

--- a/ckanext/unhcr/templates/user/account_created.html
+++ b/ckanext/unhcr/templates/user/account_created.html
@@ -5,7 +5,7 @@
     <div class="module-content">
       {% block primary_content_inner %}
       <h1 class="page-heading">
-        {% block page_heading %}{{ _('External Account Requested') }}{% endblock %}
+        {% block page_heading %}{{ _('Partner Account Requested') }}{% endblock %}
       </h1>
       <h2>Thanks for registering</h2>
       <p>

--- a/ckanext/unhcr/templates/user/list.html
+++ b/ckanext/unhcr/templates/user/list.html
@@ -10,7 +10,7 @@
   {% for user in page.items %}
     <tr>
       <td>{{ h.linked_user(user['name'], maxlength=20) }}</td>
-      <td>{% if user.User.external %}External{% else %}UNHCR{% endif %}</td>
+      <td>{% if user.User.external %}Partner{% else %}UNHCR{% endif %}</td>
       <td>{{ user.User.state.capitalize() }}</td>
     </tr>
   {% endfor %}

--- a/ckanext/unhcr/templates/user/login.html
+++ b/ckanext/unhcr/templates/user/login.html
@@ -1,8 +1,8 @@
 {% ckan_extends %}
 
-{% block subtitle %}External User Login{% endblock %}
+{% block subtitle %}Partner Login{% endblock %}
 
-{% block page_heading %}External User Login{% endblock %}
+{% block page_heading %}Partner Login{% endblock %}
 
 {% block form %}
   {{ super.super() }}

--- a/ckanext/unhcr/templates/user/new.html
+++ b/ckanext/unhcr/templates/user/new.html
@@ -11,7 +11,7 @@
     <div class="module-content">
       {% block primary_content_inner %}
       <h1 class="page-heading">
-        {% block page_heading %}{{ _('Request an External Account') }}{% endblock %}
+        {% block page_heading %}{{ _('Request an Account') }}{% endblock %}
       </h1>
       {{ form | safe }}
       {% endblock %}

--- a/ckanext/unhcr/templates/user/read_base.html
+++ b/ckanext/unhcr/templates/user/read_base.html
@@ -30,7 +30,7 @@
     <dt>{{ _('Organisation') }}</dt>
     <dd>
       {% if user.external %}
-        <span class="label label-warning">External</span>
+        <span class="label label-warning">Partner</span>
       {% else %}
         UNHCR
       {% endif %}</dd>

--- a/ckanext/unhcr/templates/user/snippets/login_sidebar.html
+++ b/ckanext/unhcr/templates/user/snippets/login_sidebar.html
@@ -12,7 +12,7 @@
 </section>
 
 <section class="module module-narrow module-shallow">
-  <h2 class="module-heading"><i class="fa fa-user"></i> External Users</h2>
+  <h2 class="module-heading"><i class="fa fa-user"></i> Partners</h2>
   <nav>
     <div class="module-content">
       <ul class="list-unstyled nav nav-simple">

--- a/ckanext/unhcr/tests/test_controllers.py
+++ b/ckanext/unhcr/tests/test_controllers.py
@@ -1957,7 +1957,7 @@ class TestUserRegister(base.FunctionalTestBase):
 
         # 'success' page content
         assert_equals(resp.status_int, 200)
-        assert_in('External Account Requested', resp.body)
+        assert_in('Partner Account Requested', resp.body)
         assert_in("We'll send an email with further instructions", resp.body)
 
     def test_register_empty_message(self):
@@ -1988,7 +1988,7 @@ class TestUserRegister(base.FunctionalTestBase):
         self.payload['email'] = 'fred@unhcr.org'
         resp = self.app.post(url_for('user.register'), self.payload)
         assert_in(
-            "Users with an @unhcr.org email may not register for an external account.",
+            "Users with an @unhcr.org email may not register for a partner account.",
             resp.body
         )
         action = toolkit.get_action("user_show")


### PR DESCRIPTION
I've only changed this in the front-end. I've left all the internal terminology (variable/function names, etc) as "external"