### PR TITLE
fixes for 'related datasets'

### DIFF
--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -158,8 +158,12 @@ def get_linked_datasets_for_form(selected_ids=[], exclude_ids=[], context=None, 
     fq_list = []
     get_containers = toolkit.get_action('organization_list_for_user')
     containers = get_containers(context, {'id': user_id})
-    for container in containers:
-        fq_list.append('owner_org:{}'.format(container['id']))
+    deposit = get_data_deposit()
+    fq_list = [
+        "owner_org:{}".format(container["id"])
+        for container in containers
+        if container["id"] != deposit["id"]
+    ]
 
     # Get search results
     search_datasets = toolkit.get_action('package_search')
@@ -167,6 +171,7 @@ def get_linked_datasets_for_form(selected_ids=[], exclude_ids=[], context=None, 
         'fq': ' OR '.join(fq_list),
         'include_private': True,
         'sort': 'organization asc, title asc',
+        'rows': 1000,
     })
 
     # Get datasets


### PR DESCRIPTION
Closes #439

This applies a couple of fixes:
1. Exclude the data deposit container from related datasets
2. Increase the number of packages in the drop-down (we were previously only showing 10 :grimacing:  ). I've bumped it to 1000 which is the max we can request at once. I figure if that becomes a meaningful limit, we actually need to switch it to an autocomplete backed by a JSON endpoint, but this will get us to a point where everything currently in the DB is select-able for now.

Note: this fix targets master