### PR TITLE
store/expose user who approved/rejected user account requests

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -702,6 +702,7 @@ def access_request_update(context, data_dict):
         raise toolkit.Invalid("Unknown Object Type")
 
     request.status = status
+    request.actioned_by = model.User.by_name(context['user']).id
     model.Session.commit()
     model.Session.refresh(request)
 

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -326,6 +326,13 @@ def get_existing_access_request(user_id, object_id, status):
     ).all()
 
 
+def get_access_request_for_user(user_id):
+    return model.Session.query(AccessRequest).filter(
+        AccessRequest.object_id==user_id,
+        AccessRequest.object_type=='user',
+    ).one_or_none()
+
+
 # Deposited datasets
 
 cached_deposit = None

--- a/ckanext/unhcr/models.py
+++ b/ckanext/unhcr/models.py
@@ -50,6 +50,7 @@ class AccessRequest(Base):
     )
     object_id = Column(UnicodeText, nullable=False)
     data = Column(MutableDict.as_mutable(JSONB), nullable=True)
+    actioned_by = Column(UnicodeText, nullable=True)  # user who approved or rejected the request
 
 
 def create_metric_columns():
@@ -91,6 +92,14 @@ def add_access_request_data_column():
     )
     model.Session.commit()
 
+def add_access_request_actioned_by_column():
+    table = AccessRequest.__tablename__
+    model.Session.execute(
+        u"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS actioned_by text;".format(
+            table=table
+        )
+    )
+    model.Session.commit()
 
 def create_tables():
     if not TimeSeriesMetric.__table__.exists():
@@ -105,4 +114,5 @@ def create_tables():
         log.info(u'AccessRequest database table created')
 
     add_access_request_data_column()
+    add_access_request_actioned_by_column()
     extend_access_request_object_type_enum()

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -297,6 +297,7 @@ class UnhcrPlugin(
             # Access requests
             'get_pending_requests_total': helpers.get_pending_requests_total,
             'get_existing_access_request': helpers.get_existing_access_request,
+            'get_access_request_for_user': helpers.get_access_request_for_user,
             # Deposited datasets
             'get_data_deposit': helpers.get_data_deposit,
             'get_data_curation_users': helpers.get_data_curation_users,

--- a/ckanext/unhcr/templates/user/read_base.html
+++ b/ckanext/unhcr/templates/user/read_base.html
@@ -57,6 +57,13 @@
     </dd>
   </dl>
   {% endif %}
+  {% set access_request = h.get_access_request_for_user(user.id) %}
+  {% if user.external and access_request and access_request.actioned_by %}
+  <dl>
+    <dt>Account {{ access_request.status }} by</dt>
+    <dd>{{ h.linked_user(access_request.actioned_by) }}</dd>
+  </dl>
+  {% endif %}
   {% if is_myself %}
     <dl>
       <dt class="key">

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -826,6 +826,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
         assert_equals(0, len(orgs))
         assert_equals('requested', self.container_request.status)
+        assert_equals(None, self.container_request.actioned_by)
 
     def test_access_request_update_approve_container_container_admin(self):
         mock_mailer = mock.Mock()
@@ -842,6 +843,10 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             )
             assert_equals(self.container1['id'], orgs[0]['id'])
             assert_equals('approved', self.container_request.status)
+            assert_equals(
+                self.container1_admin["id"],
+                self.container_request.actioned_by,
+            )
 
             mock_mailer.assert_called_once()
             assert_equals(
@@ -869,6 +874,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
         assert_equals(0, len(orgs))
         assert_equals('requested', self.container_request.status)
+        assert_equals(None, self.container_request.actioned_by)
 
     def test_access_request_update_reject_container_container_admin(self):
         action = toolkit.get_action("access_request_update")
@@ -883,6 +889,10 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
         assert_equals(0, len(orgs))
         assert_equals('rejected', self.container_request.status)
+        assert_equals(
+            self.container1_admin["id"],
+            self.container_request.actioned_by
+        )
 
     def test_access_request_update_approve_dataset_standard_user(self):
         action = toolkit.get_action("access_request_update")
@@ -898,6 +908,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
         assert_equals(0, len(collaborators))
         assert_equals('requested', self.dataset_request.status)
+        assert_equals(None, self.dataset_request.actioned_by)
 
     def test_access_request_update_approve_dataset_container_admin(self):
         mock_mailer = mock.Mock()
@@ -913,6 +924,10 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             )
             assert_equals(self.requesting_user["id"], collaborators[0]["user_id"])
             assert_equals('approved', self.dataset_request.status)
+            assert_equals(
+                self.container1_admin["id"],
+                self.dataset_request.actioned_by,
+            )
 
             mock_mailer.assert_called_once()
             assert_equals(self.dataset_request.object_id, mock_mailer.call_args[0][0])
@@ -934,6 +949,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
         assert_equals(0, len(collaborators))
         assert_equals('requested', self.dataset_request.status)
+        assert_equals(None, self.dataset_request.actioned_by)
 
     def test_access_request_update_reject_dataset_container_admin(self):
         action = toolkit.get_action("access_request_update")
@@ -947,6 +963,10 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
         assert_equals(0, len(collaborators))
         assert_equals('rejected', self.dataset_request.status)
+        assert_equals(
+            self.container1_admin["id"],
+            self.dataset_request.actioned_by
+        )
 
     def test_access_request_update_approve_user_standard_user(self):
         action = toolkit.get_action("access_request_update")
@@ -961,6 +981,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             {"ignore_auth": True}, {"id": self.pending_user["id"]}
         )
         assert_equals(model.State.PENDING, user['state'])
+        assert_equals(None, self.user_request.actioned_by)
 
     def test_access_request_update_approve_user_container_admin(self):
         mock_mailer = mock.Mock()
@@ -976,6 +997,10 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             )
             assert_equals(model.State.ACTIVE, user['state'])
             assert_equals('approved', self.user_request.status)
+            assert_equals(
+                self.container1_admin["id"],
+                self.user_request.actioned_by,
+            )
 
             mock_mailer.assert_called_once()
             assert_equals(
@@ -1004,6 +1029,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             {"ignore_auth": True}, {"id": self.pending_user["id"]}
         )
         assert_equals(model.State.PENDING, user['state'])
+        assert_equals(None, self.user_request.actioned_by)
 
     def test_access_request_update_reject_user_container_admin(self):
         action = toolkit.get_action("access_request_update")
@@ -1017,6 +1043,10 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
         )
         assert_equals(model.State.DELETED, user['state'])
         assert_equals('rejected', self.user_request.status)
+        assert_equals(
+            self.container1_admin["id"],
+            self.user_request.actioned_by
+        )
 
     def test_access_request_update_invalid_inputs(self):
         action = toolkit.get_action("access_request_update")


### PR DESCRIPTION
- Store the user who approved or rejected an access request on the AccessRequest object (this also applies to container/organisation access requests - it is a useful data point there too)
- Expose the user who approved or rejected a user account request on the user detail page

Refs #434 