### PR TITLE
clarify 'submit' CTA in deposit alert

### DIFF
--- a/ckanext/unhcr/templates/package/read.html
+++ b/ckanext/unhcr/templates/package/read.html
@@ -14,13 +14,12 @@
       {% elif curation['state'] == 'draft' %}
 
         {% if curation['role'] == 'depositor' %}
+            <a style="float: right" href="#curation-submit" role="button" class="btn btn-warning" data-toggle="modal" title="{{ link_help }}" data-target="#curation-submit">
+              Submit Dataset
+            </a>
+
           <p>{% trans %}This deposited dataset is in <strong>draft</strong> state. You can make further edits if necessary.{% endtrans %}</p>
-          <p>{% trans %}Once all edits are made
-            <a href="#curation-submit" role="button" class="btn btn-warning" data-toggle="modal" title="{{ link_help }}" data-target="#curation-submit">
-              Submit the dataset
-            </a> for review by the curation team.{% endtrans %}
-          </p>
-          <p>{% trans %}<strong>Note:</strong> You won't be able to edit the dataset once submitted. You can submit a dataset for curation even if it does not pass the validation requirements.{% endtrans %}</p>
+          <p>{% trans %}Once all edits are made submit the dataset for review by the curation team.{% endtrans %}</p>
         {% else %}
         <p>{% trans %}This deposited dataset is in <strong>draft</strong> state. The Depositor can still make further edits if necessary.{% endtrans %}</p>
         {% endif %}

--- a/ckanext/unhcr/templates/package/read.html
+++ b/ckanext/unhcr/templates/package/read.html
@@ -14,8 +14,13 @@
       {% elif curation['state'] == 'draft' %}
 
         {% if curation['role'] == 'depositor' %}
-          <p>{% trans %}This deposited dataset is in <strong>draft</strong> state. You can make further edits if necessary. When you want to submit it to the curation team, click on the "Submit Dataset" button on the left.{% endtrans %}</p>
-        <p>{% trans %}<strong>Note:</strong> You won't be able to edit the dataset once submitted. You can submit a dataset for curation even if it does not pass the validation requirements.{% endtrans %}</p>
+          <p>{% trans %}This deposited dataset is in <strong>draft</strong> state. You can make further edits if necessary.{% endtrans %}</p>
+          <p>{% trans %}Once all edits are made
+            <a href="#curation-submit" role="button" class="btn btn-warning" data-toggle="modal" title="{{ link_help }}" data-target="#curation-submit">
+              Submit the dataset
+            </a> for review by the curation team.{% endtrans %}
+          </p>
+          <p>{% trans %}<strong>Note:</strong> You won't be able to edit the dataset once submitted. You can submit a dataset for curation even if it does not pass the validation requirements.{% endtrans %}</p>
         {% else %}
         <p>{% trans %}This deposited dataset is in <strong>draft</strong> state. The Depositor can still make further edits if necessary.{% endtrans %}</p>
         {% endif %}


### PR DESCRIPTION
One of the bits of feedback from the pilot is it needs to be clearer (for all users internal and external) that once you've finished editing a deposited dataset you need to actively submit it to the curation team for review. This is a fairly crude attempt to make the call to action clearer, but other suggestions welcome.