### PR TITLE
fix some python2 unicode errors

### DIFF
--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -24,9 +24,9 @@ def sysadmin():
         return toolkit.abort(404, 'User not found')
 
     if status:
-        toolkit.h.flash_success('Promoted {} to sysadmin'.format(user['display_name']))
+        toolkit.h.flash_success(u'Promoted {} to sysadmin'.format(user['display_name']))
     else:
-        toolkit.h.flash_success('Revoked sysadmin permission from {}'.format(user['display_name']))
+        toolkit.h.flash_success(u'Revoked sysadmin permission from {}'.format(user['display_name']))
     return toolkit.h.redirect_to('unhcr_admin.index')
 
 

--- a/ckanext/unhcr/controllers/data_container.py
+++ b/ckanext/unhcr/controllers/data_container.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import logging
 from ckan import model
 import ckan.plugins.toolkit as toolkit
@@ -30,7 +32,7 @@ class DataContainerController(toolkit.BaseController):
                 mailer.mail_user(user, subj, body)
 
         # show flash message and redirect
-        toolkit.h.flash_success('Data container "{}" approved'.format(org_dict['title']))
+        toolkit.h.flash_success(u'Data container "{}" approved'.format(org_dict['title']))
         toolkit.redirect_to('data-container_read', id=id)
 
     def reject(self, id, *args, **kwargs):
@@ -52,7 +54,7 @@ class DataContainerController(toolkit.BaseController):
         delete_core.organization_purge({'model': model}, {'id': id})
 
         # show flash message and redirect
-        toolkit.h.flash_error('Data container "{}" rejected'.format(org_dict['title']))
+        toolkit.h.flash_error(u'Data container "{}" rejected'.format(org_dict['title']))
         toolkit.redirect_to('data-container_index')
 
     # Membership

--- a/ckanext/unhcr/controllers/extended_package.py
+++ b/ckanext/unhcr/controllers/extended_package.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import logging
 from ckan import model
 import ckan.plugins.toolkit as toolkit
@@ -196,7 +198,7 @@ class ExtendedPackageController(PackageController):
 
         if toolkit.h.can_download(dataset):
             toolkit.h.flash_notice(
-                'You already have access to download resources from {}'.format(
+                u'You already have access to download resources from {}'.format(
                     dataset['title']
                 )
             )
@@ -236,7 +238,7 @@ class ExtendedPackageController(PackageController):
             mailer.mail_user_by_id(recipient['name'], subj, body)
 
         toolkit.h.flash_success(
-            'Requested access to download resources from {}'.format(
+            u'Requested access to download resources from {}'.format(
                 dataset['title']
             )
         )


### PR DESCRIPTION
Started looking into #451 . It isn't just one bug. Basically the issue is there are a bunch of places where we are throwing `UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 6: ordinal not in range(128)` where the dataset name is "Yaoundé et Douala: Evaluation des impacts du COVID-19 sur les moyens de subsistance des réfugiés urbains (avril 2020)" or whatever.

Interestingly in python2 there is a behaviour difference between `format()` and `%`:

```py
>>> 'hello {}'.format(u'Chris')
'hello Chris'

>>> 'hello {}'.format(u'Adrià')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe0' in position 4: ordinal not in range(128)
```

but

```py
>>> 'hello %s' % u'Chris'
u'hello Chris'

>>> 'hello %s' % u'Adrià'
u'hello Adri\xe0'
```

so.. that's a bit of fun. This PR will fix a bunch of these errors, but there will inevitably be stuff I've missed. There is another bug related to #451 which needs fixing in the collaborators plugin:

```
  File "/srv/app/src/ckanext-collaborators/ckanext/collaborators/mailer.py", line 11, in _compose_email_subj
    toolkit.config.get('ckan.site_title'), dataset.title)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 6: ordinal not in range(128)
```

https://github.com/okfn/ckanext-collaborators/blob/b024c3cde7a725a3042a16e57bd22a3793889a6e/ckanext/collaborators/mailer.py#L9-L11

I'll do that in another PR to the collaborators plugin but I see you've reviewed some other PRs so I will follow those up next.
