### PR TITLE
set a default target container for deposits if we can

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -1194,6 +1194,7 @@ def user_show(up_func, context, data_dict):
 
     user['focal_point'] = extras['focal_point']
     user['expiry_date'] = extras['expiry_date']
+    user['containers'] = extras['containers']
 
     return user
 
@@ -1208,6 +1209,9 @@ def user_create(up_func, context, data_dict):
     if not data_dict.get('focal_point'):
         raise toolkit.ValidationError({'focal_point': ["A focal point must be specified"]})
 
+    if not isinstance(data_dict.get('containers'), list):
+        raise toolkit.ValidationError({'containers': ["Specify one or more containers"]})
+
     plugin_extras = _init_plugin_extras(context['user_obj'].plugin_extras)
     expiry_date = datetime.date.today() + datetime.timedelta(
         days=toolkit.config.get(
@@ -1217,6 +1221,7 @@ def user_create(up_func, context, data_dict):
     )
     plugin_extras['unhcr']['expiry_date'] = expiry_date.isoformat()
     plugin_extras['unhcr']['focal_point'] = data_dict['focal_point']
+    plugin_extras['unhcr']['containers'] = data_dict['containers']
     context['user_obj'].plugin_extras = plugin_extras
 
     if not context.get('defer_commit'):
@@ -1225,6 +1230,7 @@ def user_create(up_func, context, data_dict):
 
     user['expiry_date'] = plugin_extras['unhcr']['expiry_date']
     user['focal_point'] = plugin_extras['unhcr']['focal_point']
+    user['containers'] = plugin_extras['unhcr']['containers']
     return user
 
 
@@ -1240,7 +1246,8 @@ def _init_plugin_extras(plugin_extras):
 def _validate_plugin_extras(extras):
     CUSTOM_FIELDS = [
         {'name': 'focal_point', 'default': ''},
-        {'name': 'expiry_date', 'default': None}
+        {'name': 'expiry_date', 'default': None},
+        {'name': 'containers',  'default': []},
     ]
     if not extras:
         extras = {}

--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -1194,7 +1194,7 @@ def user_show(up_func, context, data_dict):
 
     user['focal_point'] = extras['focal_point']
     user['expiry_date'] = extras['expiry_date']
-    user['containers'] = extras['containers']
+    user['default_containers'] = extras['default_containers']
 
     return user
 
@@ -1209,8 +1209,8 @@ def user_create(up_func, context, data_dict):
     if not data_dict.get('focal_point'):
         raise toolkit.ValidationError({'focal_point': ["A focal point must be specified"]})
 
-    if not isinstance(data_dict.get('containers'), list):
-        raise toolkit.ValidationError({'containers': ["Specify one or more containers"]})
+    if not isinstance(data_dict.get('default_containers'), list):
+        raise toolkit.ValidationError({'default_containers': ["Specify one or more containers"]})
 
     plugin_extras = _init_plugin_extras(context['user_obj'].plugin_extras)
     expiry_date = datetime.date.today() + datetime.timedelta(
@@ -1221,7 +1221,7 @@ def user_create(up_func, context, data_dict):
     )
     plugin_extras['unhcr']['expiry_date'] = expiry_date.isoformat()
     plugin_extras['unhcr']['focal_point'] = data_dict['focal_point']
-    plugin_extras['unhcr']['containers'] = data_dict['containers']
+    plugin_extras['unhcr']['default_containers'] = data_dict['default_containers']
     context['user_obj'].plugin_extras = plugin_extras
 
     if not context.get('defer_commit'):
@@ -1230,7 +1230,7 @@ def user_create(up_func, context, data_dict):
 
     user['expiry_date'] = plugin_extras['unhcr']['expiry_date']
     user['focal_point'] = plugin_extras['unhcr']['focal_point']
-    user['containers'] = plugin_extras['unhcr']['containers']
+    user['default_containers'] = plugin_extras['unhcr']['default_containers']
     return user
 
 
@@ -1247,7 +1247,7 @@ def _validate_plugin_extras(extras):
     CUSTOM_FIELDS = [
         {'name': 'focal_point', 'default': ''},
         {'name': 'expiry_date', 'default': None},
-        {'name': 'containers',  'default': []},
+        {'name': 'default_containers',  'default': []},
     ]
     if not extras:
         extras = {}

--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -112,7 +112,7 @@ class RegisterView(BaseRegisterView):
         data_dict['state'] = context['model'].State.PENDING
         deposit = get_data_deposit()
         containers = [data_dict.get('container'), deposit['id']]
-        data_dict['containers'] = containers
+        data_dict['default_containers'] = containers
 
         try:
             model.Session.begin_nested()
@@ -123,7 +123,7 @@ class RegisterView(BaseRegisterView):
                 'object_type': 'user',
                 'message': data_dict['message'],
                 'role': 'member',
-                'data': {'containers': containers}
+                'data': {'default_containers': containers}
             }
             toolkit.get_action(u'access_request_create')(
                 {'user': user['id'], 'ignore_auth': True, 'defer_commit': True},

--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -112,6 +112,7 @@ class RegisterView(BaseRegisterView):
         data_dict['state'] = context['model'].State.PENDING
         deposit = get_data_deposit()
         containers = [data_dict.get('container'), deposit['id']]
+        data_dict['containers'] = containers
 
         try:
             model.Session.begin_nested()

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -692,6 +692,15 @@ def get_user_deposited_drafts():
     return datasets
 
 
+def get_default_container_for_user():
+    context = {'model': model, 'user': toolkit.c.user}
+    user = toolkit.get_action('user_show')(context, {'id': toolkit.c.user})
+    log.info(user)
+    if len(user['containers']) > 0:
+        return user['containers'][0]
+    return 'unknown'
+
+
 # Internal activity
 
 def create_curation_activity(

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -417,6 +417,7 @@ def get_data_curation_users(dataset):
     users = []
     for item in depadmins + curators + container_admins:
         user = toolkit.get_action('user_show')(context, {'id': item[0]})
+        user.pop('containers', None)
         users.append(user)
 
     users = [dict(tup) for tup in {tuple(u.items()) for u in users}]  # de-dupe

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -417,7 +417,7 @@ def get_data_curation_users(dataset):
     users = []
     for item in depadmins + curators + container_admins:
         user = toolkit.get_action('user_show')(context, {'id': item[0]})
-        user.pop('containers', None)
+        user.pop('default_containers', None)
         users.append(user)
 
     users = [dict(tup) for tup in {tuple(u.items()) for u in users}]  # de-dupe
@@ -695,9 +695,8 @@ def get_user_deposited_drafts():
 def get_default_container_for_user():
     context = {'model': model, 'user': toolkit.c.user}
     user = toolkit.get_action('user_show')(context, {'id': toolkit.c.user})
-    log.info(user)
-    if len(user['containers']) > 0:
-        return user['containers'][0]
+    if len(user['default_containers']) > 0:
+        return user['default_containers'][0]
     return 'unknown'
 
 

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -279,7 +279,7 @@ def get_user_account_request_access_email_recipients(containers):
             {"id": container}
         )
     for user in recipients:
-        user.pop('containers', None)
+        user.pop('default_containers', None)
     recipients = [
         dict(tup) for tup in {tuple(sorted(r.items())) for r in recipients}
     ]  # de-dupe

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -278,6 +278,8 @@ def get_user_account_request_access_email_recipients(containers):
         recipients = recipients + get_container_request_access_email_recipients(
             {"id": container}
         )
+    for user in recipients:
+        user.pop('containers', None)
     recipients = [
         dict(tup) for tup in {tuple(sorted(r.items())) for r in recipients}
     ]  # de-dupe

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -305,6 +305,7 @@ class UnhcrPlugin(
             'get_deposited_dataset_user_curation_role': helpers.get_deposited_dataset_user_curation_role,
             'get_dataset_validation_report': helpers.get_dataset_validation_report,
             'get_user_deposited_drafts': helpers.get_user_deposited_drafts,
+            'get_default_container_for_user': helpers.get_default_container_for_user,
             # Microdata
             'get_microdata_collections': helpers.get_microdata_collections,
             # Misc

--- a/ckanext/unhcr/templates/organization/snippets/curation_modals.html
+++ b/ckanext/unhcr/templates/organization/snippets/curation_modals.html
@@ -22,10 +22,14 @@
         <div class="control-group control-select">
           <label for="field-owner_org_dest" class="control-label">Destination Data Container</label>
           <div class="controls">
+            {% set default_container = h.get_default_container_for_user() %}
             <select id="field-owner_org_dest" name="owner_org_dest">
               {% set orgs = h.get_all_data_containers(exclude_ids=[deposit.id], include_unknown=True) %}
               {% for org in orgs %}
-                <option value="{{ org.id }}">{{ org.title }}</option>
+                <option
+                  value="{{ org.id }}"
+                  {% if org.id == default_container %}selected="selected"{% endif %}
+                >{{ org.title }}</option>
               {% endfor %}
             </select>
           </div>

--- a/ckanext/unhcr/tests/factories.py
+++ b/ckanext/unhcr/tests/factories.py
@@ -1,4 +1,9 @@
+import factory
 from ckan.tests import factories
+
+
+def _generate_email(user):
+    return "{0}@externaluser.com".format(user.name).lower()
 
 
 class DataContainer(factories.Organization):
@@ -39,3 +44,10 @@ class DepositedDataset(factories.Dataset):
     owner_org = 'id-data-deposit'
     owner_org_dest = 'id-data-target'
     visibility = 'public'
+
+
+class ExternalUser(factories.User):
+
+    email = factory.LazyAttribute(_generate_email)
+    focal_point = 'focal-point'
+    containers = []

--- a/ckanext/unhcr/tests/factories.py
+++ b/ckanext/unhcr/tests/factories.py
@@ -50,4 +50,4 @@ class ExternalUser(factories.User):
 
     email = factory.LazyAttribute(_generate_email)
     focal_point = 'focal-point'
-    containers = []
+    default_containers = []

--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -773,11 +773,7 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
 
         self.requesting_user = core_factories.User()
         self.standard_user = core_factories.User()
-        self.pending_user = core_factories.User(
-            state=model.State.PENDING,
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        self.pending_user = factories.ExternalUser(state=model.State.PENDING)
 
         self.container1_admin = core_factories.User()
         self.container1 = factories.DataContainer(
@@ -1151,10 +1147,7 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
         )
 
     def test_target_user_is_not_pending(self):
-        target_user = core_factories.User(
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        target_user = factories.ExternalUser()
         action = toolkit.get_action("external_user_update_state")
         assert_raises(
             toolkit.NotAuthorized,
@@ -1164,11 +1157,7 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
         )
 
     def test_requesting_user_is_not_container_admin(self):
-        target_user = core_factories.User(
-            state=model.State.PENDING,
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        target_user = factories.ExternalUser(state=model.State.PENDING)
         access_request_data_dict = {
             'object_id': target_user['id'],
             'object_type': 'user',
@@ -1191,11 +1180,7 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
         )
 
     def test_requesting_user_is_not_admin_of_required_container(self):
-        target_user = core_factories.User(
-            state=model.State.PENDING,
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        target_user = factories.ExternalUser(state=model.State.PENDING)
         requesting_user = core_factories.User()
         container2 = factories.DataContainer(
             users=[{"name": requesting_user["name"], "capacity": "admin"}]
@@ -1221,11 +1206,7 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
         )
 
     def test_no_access_request(self):
-        target_user = core_factories.User(
-            state=model.State.PENDING,
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        target_user = factories.ExternalUser(state=model.State.PENDING)
         action = toolkit.get_action("external_user_update_state")
         assert_raises(
             toolkit.NotAuthorized,
@@ -1235,11 +1216,7 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
         )
 
     def test_invalid_state(self):
-        target_user = core_factories.User(
-            state=model.State.PENDING,
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        target_user = factories.ExternalUser(state=model.State.PENDING)
         access_request_data_dict = {
             'object_id': target_user['id'],
             'object_type': 'user',
@@ -1270,11 +1247,7 @@ class TestExternalUserUpdateState(base.FunctionalTestBase):
         )
 
     def test_success(self):
-        target_user = core_factories.User(
-            state=model.State.PENDING,
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        target_user = factories.ExternalUser(state=model.State.PENDING)
         access_request_data_dict = {
             'object_id': target_user['id'],
             'object_type': 'user',
@@ -1303,7 +1276,7 @@ class TestPackageSearch(base.FunctionalTestBase):
 
     def test_package_search_permissions(self):
         internal_user = core_factories.User()
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         dataset = factories.Dataset(private=True)
         action = toolkit.get_action("package_search")
 
@@ -1339,7 +1312,7 @@ class TestDatasetCollaboratorCreate(base.FunctionalTestBase):
 
     def test_external_user(self):
         sysadmin = core_factories.Sysadmin(name='sysadmin', id='sysadmin')
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         dataset = factories.Dataset(private=True)
 
         action = toolkit.get_action("dataset_collaborator_create")
@@ -1381,7 +1354,7 @@ class TestOrganizationMemberCreate(base.FunctionalTestBase):
 
     def test_external_user(self):
         sysadmin = core_factories.Sysadmin(name='sysadmin', id='sysadmin')
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         container = factories.DataContainer()
 
         action = toolkit.get_action("organization_member_create")
@@ -1401,10 +1374,9 @@ class TestUserAutocomplete(base.FunctionalTestBase):
 
     def test_user_autocomplete(self):
         sysadmin = core_factories.Sysadmin(name='sysadmin', id='sysadmin')
-        core_factories.User(
+        factories.ExternalUser(
             fullname='Alice External',
             email='alice@externaluser.com',
-            focal_point='REACH',
         )
         core_factories.User(fullname='Bob Internal')
         core_factories.User(fullname='Carlos Internal')
@@ -1432,7 +1404,7 @@ class TestUserAutocomplete(base.FunctionalTestBase):
 class TestUserActions(base.FunctionalTestBase):
     def test_user_list(self):
         sysadmin = core_factories.Sysadmin()
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         internal_user = core_factories.User()
         default_user = toolkit.get_action('get_site_user')({ 'ignore_auth': True })
 
@@ -1456,10 +1428,7 @@ class TestUserActions(base.FunctionalTestBase):
 
     def test_user_show(self):
         sysadmin = core_factories.Sysadmin()
-        external_user = core_factories.User(
-            email='fred@externaluser.com',
-            focal_point='REACH'
-        )
+        external_user = factories.ExternalUser()
         internal_user = core_factories.User()
 
         action = toolkit.get_action('user_show')
@@ -1475,10 +1444,7 @@ class TestUserActions(base.FunctionalTestBase):
         assert '' == user['focal_point']
 
     def test_unhcr_plugin_extras_with_data(self):
-        user = core_factories.User(
-            email='fred@externaluser.com',
-            focal_point='Alice',
-        )
+        user = factories.ExternalUser(focal_point='Alice')
         context = {'user': user['name']}
         user = toolkit.get_action('user_show')(context, {'id': user['id']})
         assert 'expiry_date' in user

--- a/ckanext/unhcr/tests/test_auth.py
+++ b/ckanext/unhcr/tests/test_auth.py
@@ -121,7 +121,7 @@ class TestAuthUI(base.FunctionalTestBase):
     def test_external_users_endpoints(self):
         app = self._get_test_app()
 
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         dataset = factories.Dataset()
         container = factories.DataContainer()
         deposit = factories.DataContainer(
@@ -333,7 +333,7 @@ class TestAuthUnit(base.FunctionalTestBase):
             )
 
     def test_external_users_core_actions(self):
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
 
         core_auth_modules = [
             'ckan.logic.auth.create',
@@ -356,7 +356,7 @@ class TestAuthUnit(base.FunctionalTestBase):
                     )
 
     def test_external_users_plugin_actions(self):
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
 
         for plugin in plugins.PluginImplementations(plugins.IAuthFunctions):
             for action in plugin.get_auth_functions().keys():
@@ -370,7 +370,7 @@ class TestAuthUnit(base.FunctionalTestBase):
                     )
 
     def test_external_users_always_allowed_actions(self):
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
 
         # these actions should always return True,
         # regardless of the content of data_dict
@@ -388,7 +388,7 @@ class TestAuthUnit(base.FunctionalTestBase):
             assert_equals(True, toolkit.check_access(action, context))
 
     def test_organization_show(self):
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         internal_user = core_factories.User()
         container = factories.DataContainer()
         deposit = factories.DataContainer(
@@ -432,7 +432,7 @@ class TestAuthUnit(base.FunctionalTestBase):
         )
 
     def test_external_user_approved_deposit(self):
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
 
         target = factories.DataContainer(
             id='data-target',
@@ -613,7 +613,7 @@ class TestPackageCreateAuth(base.FunctionalTestBase):
     @helpers.change_config('ckan.auth.create_unowned_dataset', False)
     def test_integration_new_deposit(self):
         # everyone can create datasets in the data-deposit
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         resp = self.app.get(
             url='/deposited-dataset/new',
             extra_environ={'REMOTE_USER': external_user['name'].encode('ascii')},
@@ -629,7 +629,7 @@ class TestPackageCreateAuth(base.FunctionalTestBase):
 
     @helpers.change_config('ckan.auth.create_unowned_dataset', False)
     def test_integration_new_dataset(self):
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         # external_user can't create a new dataset
         resp = self.app.get(
             url='/dataset/new',
@@ -660,7 +660,7 @@ class TestPackageCreateAuth(base.FunctionalTestBase):
     @helpers.change_config('ckan.auth.create_unowned_dataset', False)
     def test_integration_edit_deposit(self):
         # everyone can edit their own draft deposited datasets
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         external_deposit = factories.DepositedDataset(
             name='dataset1',
             owner_org='data-deposit',
@@ -692,7 +692,7 @@ class TestPackageCreateAuth(base.FunctionalTestBase):
 class TestExternalUserPackageAuths(base.FunctionalTestBase):
 
     def setup(self):
-        self.external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        self.external_user = factories.ExternalUser()
         user = core_factories.User()
 
         target = factories.DataContainer(
@@ -816,10 +816,7 @@ class TestUserAuth(base.FunctionalTestBase):
     def setup(self):
         super(TestUserAuth, self).setup()
         self.sysadmin = core_factories.Sysadmin()
-        self.external_user = core_factories.User(
-            email='fred@externaluser.com',
-            focal_point='REACH'
-        )
+        self.external_user = factories.ExternalUser()
         self.internal_user = core_factories.User()
 
     def test_user_show_internal_user(self):

--- a/ckanext/unhcr/tests/test_auth.py
+++ b/ckanext/unhcr/tests/test_auth.py
@@ -67,7 +67,7 @@ class TestAuthUI(base.FunctionalTestBase):
 
         container_member = core_factories.User()
         dataset_member = core_factories.User()
-        external_user = core_factories.User()
+        other_user = core_factories.User()
         data_container = factories.DataContainer(
             users=[{'name': container_member['name'], 'capacity': 'admin'}]
         )
@@ -102,12 +102,12 @@ class TestAuthUI(base.FunctionalTestBase):
 
         response = app.get(
             '/dataset/{}'.format(dataset['name']),
-            extra_environ={ 'REMOTE_USER': str(external_user['name']) },
+            extra_environ={ 'REMOTE_USER': str(other_user['name']) },
             status=200,
         )
-        # external_user is allowed to see the dataset_read view too
+        # other_user is allowed to see the dataset_read view too
         assert_not_in('You must be logged in', response.body)
-        # external_user is not allowed to download the resource
+        # other_user is not allowed to download the resource
         assert_in(
             'You are not authorized to download the resources from this dataset',
             response.body

--- a/ckanext/unhcr/tests/test_controllers.py
+++ b/ckanext/unhcr/tests/test_controllers.py
@@ -1563,11 +1563,7 @@ class TestAccessRequests(base.FunctionalTestBase):
         self.sysadmin = core_factories.Sysadmin()
         self.requesting_user = core_factories.User()
         self.standard_user = core_factories.User()
-        self.pending_user = core_factories.User(
-            state=model.State.PENDING,
-            email='fred@externaluser.com',
-            focal_point='REACH',
-        )
+        self.pending_user = factories.ExternalUser(state=model.State.PENDING)
 
         self.container1_admin = core_factories.User()
         self.container1 = factories.DataContainer(

--- a/ckanext/unhcr/tests/test_helpers.py
+++ b/ckanext/unhcr/tests/test_helpers.py
@@ -53,7 +53,7 @@ class TestHelpers(base.FunctionalTestBase):
         container1 = factories.DataContainer(title='container1', visible_external=True)
         container2 = factories.DataContainer(title='container2', visible_external=False)
         internal_user = core_factories.User()
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
 
         # internal_user can see all the containers
         assert_equals(

--- a/ckanext/unhcr/tests/test_validators.py
+++ b/ckanext/unhcr/tests/test_validators.py
@@ -72,7 +72,7 @@ class TestValidators(base.FunctionalTestBase):
         deposit = factories.DataContainer(id='data-deposit')
         target = factories.DataContainer(id='data-target', visible_external=False)
         internal_user = core_factories.User()
-        external_user = core_factories.User(email='fred@externaluser.com', focal_point='REACH')
+        external_user = factories.ExternalUser()
         assert_raises(
             toolkit.Invalid,
             validators.deposited_dataset_owner_org_dest,


### PR DESCRIPTION
- Store containers for external users on `user.plugin_extras`
- Clean up tests by adding an `ExternalUser` factory (refs  #454 ). On reflection, I think it is OK to just keep using the core factory for internal users. We don't need a specific `InternalUser` factory.
- Select container by default when users create a new deposited dataset
