### PR TITLE
fix race conditions when using defer_commit/background jobs

### DIFF
--- a/ckanext/unhcr/tests/test_actions.py
+++ b/ckanext/unhcr/tests/test_actions.py
@@ -1762,3 +1762,145 @@ class TestClamAVActions(base.FunctionalTestBase):
                     "metadata": {}
                 }
             )
+
+
+class TestHooks(base.FunctionalTestBase):
+
+    def setup(self):
+        super(TestHooks, self).setup()
+
+        self.container = factories.DataContainer()
+        self.dataset = factories.Dataset(owner_org=self.container['id'])
+        self.resource = factories.Resource(
+            package_id=self.dataset['id'],
+            url_type='upload',
+        )
+        self.user = core_factories.Sysadmin()
+
+        self.new_package_dict = {
+            'external_access_level': 'public_use',
+            'keywords': ['1'],
+            'archived': 'False',
+            'data_collector': 'test',
+            'data_collection_technique': 'nf',
+            'visibility': 'public',
+            'name': 'test',
+            'notes': 'test',
+            'unit_of_measurement': 'test',
+            'title': 'test',
+            'owner_org': self.container['id'],
+            'state': 'active',
+        }
+        self.new_resource_dict = {
+            'package_id': self.dataset['id'],
+            'upload': mocks.FakeFileStorage(),
+            'url': 'http://fakeurl/test.txt',
+            'url_type': 'upload',
+            'type': 'data',
+            'file_type': 'microdata',
+            'identifiability': 'anonymized_public',
+            'date_range_start': '2018-01-01',
+            'date_range_end': '2019-01-01',
+            'process_status': 'anonymized',
+            'version': '1',
+        }
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_create_resource_hook_called(self, mock_hook):
+        action = toolkit.get_action("resource_create")
+        resource = action({'user': self.user['name']}, self.new_resource_dict)
+        mock_hook.assert_called_once()
+        assert 'process_dataset_on_update' == mock_hook.call_args_list[0][0][0].__name__
+        assert resource['package_id'] == mock_hook.call_args_list[0][0][1][0]
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_create_resource_hook_not_called(self, mock_hook):
+        action = toolkit.get_action("resource_create")
+        action({'user': self.user['name'], 'job': True}, self.new_resource_dict)
+        mock_hook.assert_not_called()
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_create_package_hook_called(self, mock_hook):
+        action = toolkit.get_action("package_create")
+        dataset = action({'user': self.user['name']}, self.new_package_dict)
+        mock_hook.assert_called_once()
+        assert 'process_dataset_on_create' == mock_hook.call_args_list[0][0][0].__name__
+        assert dataset['id'] == mock_hook.call_args_list[0][0][1][0]
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_create_package_hook_not_called_job(self, mock_hook):
+        action = toolkit.get_action("package_create")
+        dataset = action({'user': self.user['name'], 'job': True}, self.new_package_dict)
+        mock_hook.assert_not_called()
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_create_package_hook_not_called_defer_commit(self, mock_hook):
+        action = toolkit.get_action("package_create")
+        dataset = action({'user': self.user['name'], 'defer_commit': True}, self.new_package_dict)
+        mock_hook.assert_not_called()
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_create_package_hook_not_called_not_active(self, mock_hook):
+        action = toolkit.get_action("package_create")
+        self.new_package_dict['state'] = 'pending'
+        dataset = action({'user': self.user['name']}, self.new_package_dict)
+        mock_hook.assert_not_called()
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_update_resource_hook_called(self, mock_hook):
+        action = toolkit.get_action("resource_update")
+        action({'user': self.user['name']}, self.resource)
+        mock_hook.assert_called_once()
+        assert 'process_dataset_on_update' == mock_hook.call_args_list[0][0][0].__name__
+        assert self.resource['package_id'] == mock_hook.call_args_list[0][0][1][0]
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_update_resource_hook_not_called(self, mock_hook):
+        action = toolkit.get_action("resource_update")
+        action({'user': self.user['name'], 'job': True}, self.resource)
+        mock_hook.assert_not_called()
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_update_package_hook_called(self, mock_hook):
+        action = toolkit.get_action("package_update")
+        action({'user': self.user['name']}, self.dataset)
+        mock_hook.assert_called_once()
+        assert 'process_dataset_on_update' == mock_hook.call_args_list[0][0][0].__name__
+        assert self.dataset['id'] == mock_hook.call_args_list[0][0][1][0]
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_update_package_hook_not_called(self, mock_hook):
+        action = toolkit.get_action("package_update")
+        action({'user': self.user['name'], 'job': True}, self.dataset)
+        action({'user': self.user['name'], 'defer_commit': True}, self.dataset)
+        self.dataset['state'] = 'pending'
+        action({'user': self.user['name']}, self.dataset)
+        mock_hook.assert_not_called()
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_delete_resource_hook_called(self, mock_hook):
+        action = toolkit.get_action("resource_delete")
+
+        action({'user': self.user['name']}, self.resource)
+        mock_hook.assert_called_once()
+        assert 'process_dataset_on_update' == mock_hook.call_args_list[0][0][0].__name__
+        assert self.resource['package_id'] == mock_hook.call_args_list[0][0][1][0]
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_delete_resource_hook_not_called(self, mock_hook):
+        action = toolkit.get_action("resource_delete")
+        action({'user': self.user['name'], 'job': True}, self.resource)
+        mock_hook.assert_not_called()
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_delete_package_hook_called(self, mock_hook):
+        action = toolkit.get_action("package_delete")
+        action({'user': self.user['name']}, self.dataset)
+        assert 'process_dataset_on_delete' == mock_hook.call_args_list[0][0][0].__name__
+        assert self.dataset['id'] == mock_hook.call_args_list[0][0][1][0]
+
+    @mock.patch('ckan.plugins.toolkit.enqueue_job')
+    def test_after_delete_package_hook_not_called(self, mock_hook):
+        action = toolkit.get_action("package_delete")
+        action({'user': self.user['name'], 'job': True}, self.dataset)
+        mock_hook.assert_not_called()


### PR DESCRIPTION
This PR fixes the situation where we kick off the `process_dataset_on_update` background job before we've commited a transaction when uploading resources via the API.

Unfortunately the suggestion in https://github.com/okfn/ckanext-unhcr/issues/448#issuecomment-740576521 doesn't help. The problem isn't that we call `after_update` before `model.repo.commit()` in `package_update` when `defer_commit == False` (although that is its own bug). The problem is that in this situation we're calling `package_update` with `defer_commit: False`. Even if we kick the job off in a chained `package_update`, we're still running the job before the transaction is committed. When we call `package_update` with `defer_commit: True` the transaction still doesn't get committed until here: https://github.com/ckan/ckan/blob/c04b6d64aadc7a647b8896279002626ca3be0a56/ckan/logic/action/create.py#L329

That said, I've attempted to capture the intent or spirit of your proposed solution here: Still use background jobs, but make sure we fire them in a place after the transaction has been committed.
Basically, what we're doing now is:
- If we call `package_update/defer_commit: False` we register `process_dataset_on_update` as a background job after the `package_update`
- If we call `package_update/defer_commit: True` we don't register the background job
- `resource_create` and `resource_update` also register `process_dataset_on_update` as a background job, so if we called one of those actions the job still gets registered (and it happens after all the transactions have been committed)

This solution works for all the situations that we currently deal with, but it  could be brittle because potentially we could add a plugin in future which change these assumptions (or possibly a behaviour change in a future version of CKAN may bite us). For example if we add another action which calls `package_update/defer_commit: True` we need to add a corresponding hook for that action. If some plugin overrides `resource_create`/`resource_update` to implement `defer_commit: True` we need to account for that. If we don't like this, we could go back and have a look at another of the proposed solutions in #448

In order to do this I've had to define a second plugin due to the name conflict between the `IPackageController` and `IResourceController` hooks, so there is a related PR over at https://github.com/okfn/docker-ckan-unhcr-aws/pull/25 to add the new plugin. It is a bit awkward though. Maybe our one monoplugin should really be split up into smaller logical units?

No changes were needed for resources uploaded via the frontend using cloudstorage multipart uploads.

Closes #448