### PR TITLE
fix editing organization slug

### DIFF
--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -325,10 +325,11 @@ class UnhcrPlugin(
 
     # Always include sub-containers to container_read search
     def before_search(self, search_params):
-        if toolkit.c.controller in (
+        controllers = (
             'organization',
-            'ckanext.unhcr.controllers.extended_organization:ExtendedOrganizationController'
-        ):
+            'ckanext.unhcr.controllers.extended_organization:ExtendedOrganizationController',
+        )
+        if toolkit.c.controller in controllers and toolkit.c.action != 'edit':
             toolkit.c.include_children_selected = True
 
             # helper function


### PR DESCRIPTION
Closes #460

There's hardly any actual code here, but it requires some explanation as the issue is esoteric.

First off, here is how to reproduce the bug.

- Pick an organisation/container in your dev copy that has one or more datasets attached to it
- Edit the organisation
- Change the slug/name of the org (not the title, the field we can use in a URL in place of a UUID). Lets say for the sake of argument we're changing the slug on the Americas container from 'americas' to 'americas2'.
- At this point, several bad things will happen:
    - We'll run most of the `organization_update` code ok, but then throw a `NotFound` when we call `model_dictize.group_dictize()` right at the end of the function. I've included a stacktrace for that below*
    - We will be redirected to a 404 page (i.e: we'll end up on `/data-container/americas` even though `/data-container/americas2` would now be the correct URL)
    - If you try and visit any dataset page for a dataset assigned to the Americas container after this, it will throw the error we see in https://github.com/okfn/ckanext-unhcr/issues/460 (this can then be fixed by rebuilding the solr index at which point those datasets become viewable again)

So.. Basically the issue here is that somewhere in `model_dictize.group_dictize()` we trigger the `before_search()` hook. In the `before_search()` hook, we use `toolkit.c.id` to query organizations (because that's all we have in this context). This is usually fine, unless we just changed the ID because `toolkit.c.id` is still `americas` but the right ID is now `americas2`. As well as throwing an exception this seems to also have the effect of essentially poisoning the index with invalid data.
As far as I can tell, there seems to be no downside to not adding the org hierarchy query if the operation we're performing is editing an organization (whether we change the slug or not), so I've just done that but let me know if you can see a problem with that.

*Stacktrace for exception thrown when saving an organization:

```
Traceback (most recent call last):
  File "/srv/app/src_extensions/ckanext-unhcr/ckanext/unhcr/actions.py", line 204, in organization_update
    return up_func(context, data_dict)
  File "/srv/app/src_extensions/ckan/ckan/logic/action/update.py", line 637, in organization_update
    return _group_or_org_update(context, data_dict, is_org=True)
  File "/srv/app/src_extensions/ckan/ckan/logic/action/update.py", line 589, in _group_or_org_update
    return model_dictize.group_dictize(group, context)
  File "/srv/app/src_extensions/ckan/ckan/lib/dictization/model_dictize.py", line 408, in group_dictize
    package_count, packages = get_packages_for_this_group(group)
  File "/srv/app/src_extensions/ckan/ckan/lib/dictization/model_dictize.py", line 404, in get_packages_for_this_group
    q)
  File "/srv/app/src_extensions/ckan/ckan/logic/__init__.py", line 467, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src_extensions/ckan/ckan/logic/action/get.py", line 1849, in package_search
    data_dict = item.before_search(data_dict)
  File "/srv/app/src_extensions/ckanext-unhcr/ckanext/unhcr/plugin.py", line 352, in before_search
    include_siblings=False
  File "/srv/app/src/ckanext-hierarchy/ckanext/hierarchy/helpers.py", line 48, in group_tree_section
    {'include_parents':include_parents, 'include_siblings':include_siblings}, {'id': id_, 'type': type_,})
  File "/srv/app/src_extensions/ckan/ckan/logic/__init__.py", line 467, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src/ckanext-hierarchy/ckanext/hierarchy/logic/action.py", line 37, in group_tree_section
    raise p.toolkit.ObjectNotFound
NotFound
```