### PR TITLE
include username in 'account approved' email

### DIFF
--- a/ckanext/unhcr/templates/emails/user/account_approved.html
+++ b/ckanext/unhcr/templates/emails/user/account_approved.html
@@ -8,7 +8,8 @@ Dear <b>{{ recipient.fullname or recipient.name }}</b>,
 {% endcall %}
 
   {% call email.paragraph() %}
-      Your request for a RIDL user account has been approved by an administrator.
+    Your request for a RIDL user account has been approved by an administrator.
+    You can now log in with the username <strong>{{ recipient.name }}</strong>.
   {% endcall %}
 
   {% call email.action(login_url) %}


### PR DESCRIPTION
I singed up for an account on UAT and realised that in the 10 seconds between filling in the form and pressing "approve" I'd completely forgotten what username I typed in :laughing:  lets make sure we put the username in the "account approved" email