### PR TITLE
update 'login' link for EDD

### DIFF
--- a/ckanext/unhcr/templates/header.html
+++ b/ckanext/unhcr/templates/header.html
@@ -52,6 +52,14 @@
 {% endblock %}
 
 
+{% block header_account_notlogged %}
+  <li>{% link_for _('Log in'), named_route='/' %}</li>
+  {% if h.check_access('user_create') %}
+    <li>{% link_for _('Register'), named_route='user.register', class_='sub' %}</li>
+  {% endif %}
+{% endblock %}
+
+
 {% block header_logo %}
   <a class="logo" href="{{ h.url_for('home.index') }}">
     <img src="/base/images/ckan-logo.png" alt="{{ g.site_title }}" title="{{ g.site_title }}" />


### PR DESCRIPTION
Following up on feedback from client. This makes the login link in the menu point to the "choose what sort of user to log in as" page
Tbh, we could probably bin the menu completely given how few pages are actually available if you're not logged in but I think the way the parent template is laid out makes that a bit fiddly.