### PR TITLE
Add organization_list_all_fields action

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -337,8 +337,7 @@ def organization_list_all_fields(context, data_dict):
     out_list = []
     for row in result:
         raw_dict = {k:v for k,v in row.items()}
-        validated_dict, errors = lib_plugins.plugin_validate(
-            organization_plugin,
+        validated_dict, errors = organization_plugin.validate(
             context,
             raw_dict,
             schema,

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -99,6 +99,14 @@ def organization_show(next_auth, context, data_dict):
     return next_auth(context, data_dict)
 
 
+def organization_list_all_fields(next_auth, context, data_dict):
+    try:
+        toolkit.check_access('organization_list', context, data_dict)
+        return {'success': True}
+    except toolkit.NotAuthorized:
+        return {'success': False}
+
+
 def organization_create(context, data_dict):
     user_orgs = toolkit.get_action('organization_list_for_user')(context, {})
 

--- a/ckanext/unhcr/blueprints/user.py
+++ b/ckanext/unhcr/blueprints/user.py
@@ -49,10 +49,7 @@ class RegisterView(BaseRegisterView):
 
     def _get_container_list(self):
         context = {'model': model, 'ignore_auth': True}
-        orgs = toolkit.get_action('organization_list')(
-            context,
-            {'type': 'data-container', 'all_fields': True, 'include_extras': True}
-        )
+        orgs = toolkit.get_action('organization_list_all_fields')(context, {})
         deposit = get_data_deposit()
         containers = sorted(
             [

--- a/ckanext/unhcr/controllers/data_container.py
+++ b/ckanext/unhcr/controllers/data_container.py
@@ -89,9 +89,7 @@ class DataContainerController(toolkit.BaseController):
         # Containers
         containers = []
         if user:
-            action = 'organization_list'
-            data_dict = {'type': 'data-container', 'order_by': 'title', 'all_fields': True}
-            containers = toolkit.get_action(action)(context, data_dict)
+            containers = toolkit.get_action('organization_list_all_fields')(context, {})
             containers = filter(lambda cont: cont['name'] != deposit['name'], containers)
 
         # Roles

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -68,8 +68,7 @@ def get_all_data_containers(
 
     data_containers = []
     context = {'model': model, 'ignore_auth': True}
-    orgs = toolkit.get_action('organization_list')(context,
-        {'type': 'data-container', 'all_fields': True, 'include_extras': True})
+    orgs = toolkit.get_action('organization_list_all_fields')(context, {})
 
     for org in orgs:
         if org['id'] in exclude_ids:

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -442,7 +442,12 @@ class UnhcrPlugin(
             'organization',
             'ckanext.unhcr.controllers.extended_organization:ExtendedOrganizationController',
         )
-        if toolkit.c.controller in controllers and toolkit.c.action != 'edit':
+        if (
+            getattr(toolkit.c, "controller", None)
+            and getattr(toolkit.c, "action", None)
+            and toolkit.c.controller in controllers
+            and toolkit.c.action != 'edit'
+        ):
             toolkit.c.include_children_selected = True
 
             # helper function

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -544,6 +544,7 @@ class UnhcrPlugin(
         functions['datasets_validation_report'] = auth.datasets_validation_report
         functions['organization_create'] = auth.organization_create
         functions['organization_show'] = auth.organization_show
+        functions['organization_list_all_fields'] = auth.organization_list_all_fields
         functions['group_list_authz'] = auth.group_list_authz
         functions['package_activity_list'] = auth.package_activity_list
         functions['package_create'] = auth.package_create
@@ -574,6 +575,7 @@ class UnhcrPlugin(
             'organization_create': actions.organization_create,
             'organization_member_create': actions.organization_member_create,
             'organization_member_delete': actions.organization_member_delete,
+            'organization_list_all_fields': actions.organization_list_all_fields,
             'container_request_list': actions.container_request_list,
             'package_activity_list': actions.package_activity_list,
             'dashboard_activity_list': actions.dashboard_activity_list,

--- a/ckanext/unhcr/tests/pt/actions/test_organization_actions.py
+++ b/ckanext/unhcr/tests/pt/actions/test_organization_actions.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from ckan.plugins import toolkit
+from ckan.tests.helpers import call_action
+from ckanext.unhcr.tests import factories
+
+
+@pytest.mark.usefixtures(
+    'clean_db', 'clean_index', 'with_request_context', 'unhcr_migrate'
+)
+class TestOrganizationActions(object):
+    def setup(self):
+        factories.DataContainer(name='za', title='South Africa')
+        factories.DataContainer(name='so', title='Somalia')
+        factories.DataContainer(name='tz', title='Tanzania')
+        factories.DataContainer(name='cg', title='Congo', state='deleted')
+
+    def test_organization_list_organization_list_all_fields_no_params(self):
+        orgs = call_action(
+            'organization_list_all_fields',
+            {'ignore_auth': True},
+        )
+        assert len(orgs) == 3
+        assert [org['name'] for org in orgs] == ['so', 'za', 'tz']
+        for org in orgs:
+            assert 'country' in org
+            assert type(org['country']) == list
+            assert 'visible_external' in org
+            assert type(org['visible_external']) == bool
+            assert org['display_name'] == org['title']
+
+    def test_organization_list_organization_list_all_fields_order_by_valid(self):
+        orgs = call_action(
+            'organization_list_all_fields',
+            {'ignore_auth': True},
+            **{'order_by': 'name'}
+        )
+        assert [org['name'] for org in orgs] == ['so', 'tz', 'za']
+
+    def test_organization_list_organization_list_all_fields_order_by_invalid(self):
+        with pytest.raises(toolkit.Invalid) as e:
+            call_action(
+                'organization_list_all_fields',
+                {'ignore_auth': True},
+                **{'order_by': 'foobar'}
+            )


### PR DESCRIPTION
This PR adds a customised `organization_list` action.

```py
toolkit.get_action('organization_list_all_fields')(context, {})
```

does roughly the same thing as

```py
toolkit.get_action('organization_list')(
    context,
    {'type': 'data-container', 'all_fields': True, 'include_extras': True, 'order_by': 'title'}
)
```

(or at least the bits we need) but the call is much faster. This massively improves the render time of pages that call it :)

Closes #418