### PR TITLE
fix access_request_list_for_user for container admins

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -937,7 +937,7 @@ def access_request_list_for_user(context, data_dict):
             ),
             and_(
                 AccessRequest.object_type == "user",
-                AccessRequest.data["containers"].has_any(array(containers)),
+                AccessRequest.data["default_containers"].has_any(array(containers)),
             )
         )
     )

--- a/ckanext/unhcr/tests/nose/test_controllers.py
+++ b/ckanext/unhcr/tests/nose/test_controllers.py
@@ -1600,7 +1600,7 @@ class TestAccessRequests(base.FunctionalTestBase):
             object_type="user",
             message="",
             role="member",
-            data={'containers': [self.container1["id"]]},
+            data={'default_containers': [self.container1["id"]]},
         )
         self.user_request_container2 = AccessRequest(
             user_id=self.pending_user["id"],
@@ -1608,7 +1608,7 @@ class TestAccessRequests(base.FunctionalTestBase):
             object_type="user",
             message="",
             role="member",
-            data={'containers': [self.container2["id"]]},
+            data={'default_containers': [self.container2["id"]]},
         )
         model.Session.add(self.container1_request)
         model.Session.add(self.container2_request)


### PR DESCRIPTION
We overlooked this in https://github.com/okfn/ckanext-unhcr/pull/457/commits/4ed86f152a14ef2c3bbdfb304d87394826142cc9 :roll_eyes: 