### PR TITLE
WIP delete rejected user records (rather than set state=deleted

### DIFF
--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -412,6 +412,10 @@ def external_user_update_state(context, data_dict):
     return {'success': False}
 
 
+def external_user_delete(context, data_dict):
+    return external_user_update_state(context, data_dict)
+
+
 # Admin
 
 def user_update_sysadmin(context, data_dict):

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -562,6 +562,7 @@ class UnhcrPlugin(
         functions['access_request_update'] = auth.access_request_update
         functions['user_update_sysadmin'] = auth.user_update_sysadmin
         functions['external_user_update_state'] = auth.external_user_update_state
+        functions['external_user_delete'] = auth.external_user_delete
         functions['search_index_rebuild'] = auth.search_index_rebuild
         functions['user_show'] = auth.user_show
         return functions
@@ -601,6 +602,7 @@ class UnhcrPlugin(
             'resource_update': actions.resource_update,
             'user_update_sysadmin': actions.user_update_sysadmin,
             'external_user_update_state': actions.external_user_update_state,
+            'external_user_delete': actions.external_user_delete,
             'search_index_rebuild': actions.search_index_rebuild,
             'user_autocomplete': actions.user_autocomplete,
             'user_list': actions.user_list,

--- a/ckanext/unhcr/tests/nose/test_actions.py
+++ b/ckanext/unhcr/tests/nose/test_actions.py
@@ -1040,10 +1040,12 @@ class TestAccessRequestUpdate(base.FunctionalTestBase):
             {'id': self.user_request.id, 'status': 'rejected'}
         )
 
-        user = toolkit.get_action("user_show")(
-            {"ignore_auth": True}, {"id": self.pending_user["id"]}
+        assert_raises(
+            toolkit.ObjectNotFound,
+            toolkit.get_action("user_show"),
+            {"ignore_auth": True},
+            {"id": self.pending_user["id"]}
         )
-        assert_equals(model.State.DELETED, user['state'])
         assert_equals('rejected', self.user_request.status)
         assert_equals(
             self.container1_admin["id"],


### PR DESCRIPTION
Refs https://github.com/okfn/ckanext-unhcr/pull/480#pullrequestreview-586609359

So far this does the main thing, which is actually delete the record instead of just setting `state=m.State.DELETED`
All the tests will probably pass, but this isn't finished because we now throw on `user_show` trying to send the rejection email here:
https://github.com/okfn/ckanext-unhcr/blob/3bda2ba8537aedc08573a0e03ce56ec95503220c/ckanext/unhcr/blueprints/access_requests.py#L43-L56

because we've deleted the user we are trying to send an email to.

At the moment, the emails are a bit of a mess: The 'approve' emails get sent inside `access_request_update` (mostly by other actions we call in there) but the reject ones are sent directly in the controller. I think the correct solution to this is to move the reject emails into `access_request_update` as well. We pass in the reject reason to the action as well (might as well bung a `notify` flag in `data_dict` too). Then we build the 'reject' email subject/body before we _do the thing_, then send them after we we've done it (then if _do the thing_ was delete a user, we already have the recipient/subject/body as  strings ready to go) and send the email directly by address instead of `mail_user_by_id()`.

Also while I'm doing this, the reject email body needs a bit of customisation for the 'user' case. At the moment it doesn't make much sense.