### PR TITLE
sysadmins are always internal, regardless of email

### DIFF
--- a/ckanext/unhcr/utils.py
+++ b/ckanext/unhcr/utils.py
@@ -40,14 +40,13 @@ def user_is_external(user):
     '''
     Returns True if user email is not in the managed internal domains.
     '''
+    if user.sysadmin:
+        return False
+
     try:
         domain = user.email.split('@')[1]
     except AttributeError:
-         # Internal sysadmin user does not have email
-        if user.sysadmin:
-            return False
-        else:
-            return True
+        return True
 
     return domain not in get_internal_domains()
 


### PR DESCRIPTION
Submitting this because I noticed ckan_admin is listed as an "external" user in production because it has a non-UNHCR email.
It probably doesn't actually break anything because sysadmin bypasses all the auth checks, but conceptually an external sysadmin doesn't make any sense.