### PR TITLE
improve display of license/external access level

### DIFF
--- a/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
+++ b/ckanext/unhcr/templates/package/snippets/curation_sidebar.html
@@ -153,6 +153,6 @@
   </div>
 
   {# License #}
-  {% snippet "snippets/license.html", pkg_dict=pkg %}
+  {% snippet "package/snippets/external_access.html", pkg_dict=pkg %}
 
 </div>

--- a/ckanext/unhcr/templates/package/snippets/external_access.html
+++ b/ckanext/unhcr/templates/package/snippets/external_access.html
@@ -1,0 +1,6 @@
+<section class="module module-narrow module-shallow license">
+  <h2 class="module-heading"><i class="fa fa-lock"></i>External Access Level</h2>
+  <p class="module-content">
+    <span>{{ h.get_choice_label('external_access_level', pkg_dict.external_access_level) or 'Not available' }}</span>
+  </p>
+</section>

--- a/ckanext/unhcr/templates/snippets/license.html
+++ b/ckanext/unhcr/templates/snippets/license.html
@@ -1,6 +1,4 @@
-<section class="module module-narrow module-shallow license">
-  <h2 class="module-heading"><i class="fa fa-lock"></i>External Access Level</h2>
-  <p class="module-content">
-    <span>{{ h.get_choice_label('external_access_level', pkg_dict.external_access_level) or 'Not available' }}</span>
-  </p>
-</section>
+<span>
+External Access Level:
+{{ h.get_choice_label('external_access_level', pkg_dict.external_access_level) or 'Not available' }}
+</span>


### PR DESCRIPTION
closes #490

What I would ideally like to do here is put

```jinja
{% block resource_license %}
  <tr>
    <th scope="row">External Access Level</th>
    <td>
      <span>{{ h.get_choice_label('external_access_level', pkg.external_access_level) or 'Not available' }}</span>
    </td>
  </tr>
{% endblock %}
```

in `read_base.html` to override
https://github.com/ckan/ckanext-scheming/blob/a53ef5cc2e1af36060330101efab1c058e3d5cf3/ckanext/scheming/templates/scheming/package/resource_read.html#L40-L45

Unfortauntely because of the order we load plugins in, scheming overrides our templates rather than vice-versa. If I start changing the order we load plugins in, all kind of other crazy stuff happens. As such, I think this is the best tradeoff we can really make here :/ That said, if you've got any other ideas...