### PR TITLE
pin all extensions installed under test

### DIFF
--- a/bin/install-extensions.bash
+++ b/bin/install-extensions.bash
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 
-git clone https://github.com/ckan/ckanext-scheming
+git clone --depth 1 --branch release-2.1.0 https://github.com/ckan/ckanext-scheming
 (cd ckanext-scheming && python setup.py develop)
 
-git clone https://github.com/okfn/ckanext-hierarchy
+git clone --depth 1 --branch v0.2.2 https://github.com/okfn/ckanext-hierarchy
 (cd ckanext-hierarchy && python setup.py develop)
 
-git clone https://github.com/okfn/ckanext-collaborators
+git clone --depth 1 --branch 0.0.9 https://github.com/okfn/ckanext-collaborators
 (cd ckanext-collaborators && python setup.py develop)
 
-git clone https://github.com/keitaroinc/ckanext-s3filestore
-(cd ckanext-s3filestore && git checkout ckan-2.8 && python setup.py develop && pip install -r requirements.txt)
+git clone --depth 1 --branch ckan-2.8 https://github.com/keitaroinc/ckanext-s3filestore
+(cd ckanext-s3filestore && python setup.py develop && pip install -r requirements.txt)


### PR DESCRIPTION
Got some odd test behaviour going on because the version of ckanext-hierarchy on the tip of master is now not the one we really want to test most of the open PRs against and depending what we want to deploy to UAT next it might or might not be useful to hold off merging https://github.com/okfn/ckanext-unhcr/pull/504
We should really pin these to use the same versions as the Dockerfile and bump the two in step (even though its a bit of a PITA).
What I'm going to do is go ahead and just merge this to straight to master, then I'll rebase all the other open PRs (including #504 over it)