### PR TITLE
wrap each user interaction in a request_context under test

### DIFF
--- a/ckanext/unhcr/tests/pt/controllers/test_user.py
+++ b/ckanext/unhcr/tests/pt/controllers/test_user.py
@@ -197,25 +197,32 @@ class TestUserRegister(object):
     def test_logged_in(self, app):
         user = core_factories.User()
 
-        app.get(
-            toolkit.url_for('user.register'),
-            extra_environ={'REMOTE_USER': user['name'].encode('ascii')},
-            status=403
-        )
-        app.get(
-            toolkit.url_for('user.register'),
-            extra_environ={'REMOTE_USER': self.sysadmin['name'].encode('ascii')},
-            status=403
-        )
-        app.post(
-            toolkit.url_for('user.register'),
-            data=self.payload,
-            extra_environ={'REMOTE_USER': user['name'].encode('ascii')},
-            status=403
-        )
-        app.post(
-            toolkit.url_for('user.register'),
-            data=self.payload,
-            extra_environ={'REMOTE_USER': self.sysadmin['name'].encode('ascii')},
-            status=403
-        )
+        with app.flask_app.test_request_context():
+            app.get(
+                toolkit.url_for('user.register'),
+                extra_environ={'REMOTE_USER': user['name'].encode('ascii')},
+                status=403
+            )
+
+        with app.flask_app.test_request_context():
+            app.get(
+                toolkit.url_for('user.register'),
+                extra_environ={'REMOTE_USER': self.sysadmin['name'].encode('ascii')},
+                status=403
+            )
+
+        with app.flask_app.test_request_context():
+            app.post(
+                toolkit.url_for('user.register'),
+                data=self.payload,
+                extra_environ={'REMOTE_USER': user['name'].encode('ascii')},
+                status=403
+            )
+
+        with app.flask_app.test_request_context():
+            app.post(
+                toolkit.url_for('user.register'),
+                data=self.payload,
+                extra_environ={'REMOTE_USER': self.sysadmin['name'].encode('ascii')},
+                status=403
+            )


### PR DESCRIPTION
This gets some more tests passing, but I ended up going down a bit of a rabbit hole on this one.

The core issue I hit is basically if I have a test like this - contrived example:

```py
@pytest.mark.usefixtures('with_request_context')
def test_something(self, app):
    app.get(url, extra_environ={'REMOTE_USER': 'user1'}, status=200) # toolkit.c.user == 'user1'
    app.get(url, extra_environ={'REMOTE_USER': 'user2'}, status=200) # toolkit.c.user == 'user1'
```

`toolkit.c.user` is still `'user1'` in the second request even though I am explicitly passing `{'REMOTE_USER': 'user2'}`. This seems to be a behaviour change depending on if the URL we are requesting is served by pylons or flask which is why these tests were passing on CKAN 2.8. The solution (or workaround) seems to be to avoid the `with_request_context` decorator and then wrap each set of interactions for a given user in its own `test_request_context` if we are testing the behaviour for more than one user in one test. So rewriting this like:

```py
# no with_request_context decorator
def test_something(self, app):
    with app.flask_app.test_request_context():
        app.get(url, extra_environ={'REMOTE_USER': 'user1'}, status=200) # toolkit.c.user == 'user1'
    with app.flask_app.test_request_context():
        app.get(url, extra_environ={'REMOTE_USER': 'user2'}, status=200) # toolkit.c.user == 'user2'
```

`toolkit.c.user` is now `'user2'` in the second request.

I'm not really sure if this is a bug or a feature, but it was quite non-obvious and took a while to  figure out this was what I needed to do to get these working.

67e54c3 is a pretty straightforward swap.

c590e49 is a bit more messy. There were some other basic things that needed fixing like replacing

`toolkit.url_for(controller='package', action='resource_download', id=dataset['id'], resource_id=resource['id'])` with
`toolkit.url_for('resource.download', id=dataset['id'], resource_id=resource['id'])`

but also while I was picking this apart I realised that there was some odd naming, some situations that weren't tested and some scope to reduce duplication a bit so I basically ended up rewriting these tests. I usually try to avoid functional changes and refactoring in the same commit but that's just the way it panned out this time. The diff isn't great to read but I think the result makes more sense.