### PR TITLE
python3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: openknowledge/ckan-dev:2.9-py2
+      image: openknowledge/ckan-dev:2.9
 
     services:
       solr:
-        image: ckan/ckan-solr-dev:2.9-py2
+        image: ckan/ckan-solr-dev:2.9
 
       postgres:
-        image: ckan/ckan-postgres-dev:2.9-py2
+        image: ckan/ckan-postgres-dev:2.9
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install ckanext-unhcr plugin
         run: |
-          python setup.py develop
+          python3 setup.py develop
           pip install --upgrade -r requirements.txt
           pip install --upgrade -r dev-requirements.txt
 

--- a/bin/install-extensions.bash
+++ b/bin/install-extensions.bash
@@ -1,22 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+pip install setuptools-rust
+
 
 git clone --depth 1 --branch release-2.1.0 https://github.com/ckan/ckanext-scheming
-(cd ckanext-scheming && python setup.py develop)
+(cd ckanext-scheming && python3 setup.py develop)
 
 git clone --depth 1 --branch 0.2.3 https://github.com/okfn/ckanext-hierarchy
-(cd ckanext-hierarchy && python setup.py develop && pip install -r requirements.txt)
+(cd ckanext-hierarchy && python3 setup.py develop && pip install -r requirements.txt)
 
 git clone --depth 1 --branch v1.0.0 https://github.com/keitaroinc/ckanext-s3filestore
-(cd ckanext-s3filestore && python setup.py develop && pip install -r requirements.txt)
+(cd ckanext-s3filestore && python3 setup.py develop && pip install -r requirements.txt)
 
 git clone --depth 1 --branch v1.1.1 https://github.com/keitaroinc/ckanext-saml2auth
-(
-    cd ckanext-saml2auth &&
-    # workaround for Python 2
-    # TODO: remove when we move to Py3
-    sed -i -e "s/install_requires=\['pysaml2>=6.3.0'\],//" setup.py &&
-    pip install pysaml2==4.9.0 python2-secrets==1.0.5 &&
-    python setup.py develop
-)
+(cd ckanext-saml2auth && python3 setup.py develop)

--- a/bin/install-extensions.bash
+++ b/bin/install-extensions.bash
@@ -7,7 +7,7 @@ pip install setuptools-rust
 git clone --depth 1 --branch release-2.1.0 https://github.com/ckan/ckanext-scheming
 (cd ckanext-scheming && python3 setup.py develop)
 
-git clone --depth 1 --branch 0.2.3 https://github.com/okfn/ckanext-hierarchy
+git clone --depth 1 --branch v0.2.4 https://github.com/okfn/ckanext-hierarchy
 (cd ckanext-hierarchy && python3 setup.py develop && pip install -r requirements.txt)
 
 git clone --depth 1 --branch v1.0.0 https://github.com/keitaroinc/ckanext-s3filestore

--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import logging
 import requests
-from urlparse import urljoin
+from urllib.parse import urljoin
 from dateutil.parser import parse as parse_date
 from sqlalchemy import and_, desc, or_, select
 from sqlalchemy.dialects.postgresql import array

--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -654,7 +654,9 @@ def scan_submit(context, data_dict):
         _fail_task(context, task, error)
         raise toolkit.ValidationError(error)
     except requests.exceptions.HTTPError as e:
-        m = 'An Error occurred while sending the job: {0}'.format(e.message)
+        m = 'An Error occurred while sending the job: {0}'.format(
+            getattr(e, 'message', '')
+        )
         try:
             body = e.response.json()
         except ValueError:

--- a/ckanext/unhcr/activity.py
+++ b/ckanext/unhcr/activity.py
@@ -8,7 +8,7 @@ def create_download_activity(context, resource_id):
     """
     user = context['user']
     user_id = None
-    user_by_name = model.User.by_name(user.decode('utf8'))
+    user_by_name = model.User.by_name(user)
     if user_by_name is not None:
         user_id = user_by_name.id
 

--- a/ckanext/unhcr/activity.py
+++ b/ckanext/unhcr/activity.py
@@ -51,7 +51,7 @@ def create_curation_activity(
     if message:
         data_dict['data']['message'] = message
     if kwargs:
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             data_dict['data'][key] = value
 
     toolkit.get_action('activity_create')(activity_context, data_dict)

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -152,7 +152,7 @@ def package_create(next_auth, context, data_dict):
                 toolkit.request.path.startswith('/deposited-dataset/edit/')
             ):
                 return {'success': True}
-        except TypeError:
+        except (TypeError, RuntimeError):
             return {
                 'success': False,
                 'msg': 'package_create requires either a web request or a data_dict'

--- a/ckanext/unhcr/blueprints/deposited_dataset.py
+++ b/ckanext/unhcr/blueprints/deposited_dataset.py
@@ -45,7 +45,12 @@ def approve(package_type, dataset_id):
         # We also set type in context to allow type switching by ckan patch
         dataset = helpers.convert_deposited_dataset_to_regular_dataset(dataset)
         dataset = toolkit.get_action('package_update')(
-                dict(context.items() + {'type': dataset['type']}.items()), dataset)
+            dict(
+                list(context.items()) +
+                list({'type': dataset['type']}.items())
+            ),
+            dataset
+        )
     except toolkit.ValidationError as error:
         message = 'Deposited dataset "%s" is invalid\n(validation error summary: %s)'
         return toolkit.abort(403, message % (id, error.error_summary))

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -7,7 +7,7 @@ from ckan import model
 from ckan.lib import uploader
 from operator import itemgetter
 from ckan.logic import ValidationError
-from ckan.plugins import toolkit
+from ckan.plugins import toolkit, plugin_loaded
 import ckan.lib.helpers as core_helpers
 import ckan.lib.plugins as lib_plugins
 from ckanext.hierarchy import helpers as hierarchy_helpers
@@ -1030,6 +1030,5 @@ def nl_to_br(text):
     return Markup(result)
 
 
-def is_plugin_loaded(plugin):
-    plugins = toolkit.config.get('ckan.plugins', '').split()
-    return plugin in plugins
+def is_plugin_loaded(plugin_name):
+    return plugin_loaded(plugin_name)

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -681,7 +681,7 @@ def get_dataset_validation_report(pkg_dict, error_dict):
     for index, resource in enumerate(pkg_dict.get('resources', [])):
         try:
             fields = sorted(error_dict['resources'][index])
-        except KeyError, IndexError:
+        except (KeyError, IndexError):
             continue
         if fields:
             report['resources'].append({

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import re
-from urllib import quote
+from urllib.parse import quote
 from jinja2 import Markup, escape
 from ckan import model
 from ckan.lib import uploader

--- a/ckanext/unhcr/helpers.py
+++ b/ckanext/unhcr/helpers.py
@@ -1028,3 +1028,8 @@ def nl_to_br(text):
     result = u'\n\n'.join(u'<p>%s</p>' % p.replace('\n', Markup('<br>\n'))
                           for p in _paragraph_re.split(escape(text)))
     return Markup(result)
+
+
+def is_plugin_loaded(plugin):
+    plugins = toolkit.config.get('ckan.plugins', '').split()
+    return plugin in plugins

--- a/ckanext/unhcr/mailer.py
+++ b/ckanext/unhcr/mailer.py
@@ -5,11 +5,19 @@ import itertools
 import logging
 from ckan import model
 from ckan.plugins import toolkit
+from ckan.lib import jinja_extensions
 from ckan.lib import mailer as core_mailer
-from ckan.lib.base import render_jinja2
 from ckan.lib.dictization import model_dictize
 from ckanext.unhcr import helpers
 log = logging.getLogger(__name__)
+
+
+def render_jinja2(template_name, extra_vars):
+    env = jinja_extensions.Environment(
+        **jinja_extensions.get_jinja_env_options()
+    )
+    template = env.get_template(template_name)
+    return template.render(**extra_vars)
 
 
 # General

--- a/ckanext/unhcr/metrics.py
+++ b/ckanext/unhcr/metrics.py
@@ -141,7 +141,7 @@ def get_containers_by_date(context):
         'type': 'timeseries_graph',
         'short_title': 'Containers',
         'title': title,
-        'total': dates.values()[-1] if len(dates.values()) > 0 else None,
+        'total': list(dates.values())[-1] if len(dates.values()) > 0 else None,
         'id': slugify(title),
         'data': [
             ['x'] + [str(date) for date in dates.keys()],

--- a/ckanext/unhcr/metrics.py
+++ b/ckanext/unhcr/metrics.py
@@ -152,7 +152,7 @@ def get_containers_by_date(context):
 def get_tags(context):
     data = _get_facet_table('tags', context)
     for row in data:
-        row['link'] = toolkit.url_for('dataset', tags=row['name'])
+        row['link'] = toolkit.url_for('dataset.search', tags=row['name'])
 
     title = 'Tags'
     return {
@@ -166,7 +166,7 @@ def get_tags(context):
 def get_keywords(context):
     data = _get_facet_table('vocab_keywords', context)
     for row in data:
-        row['link'] = toolkit.url_for('dataset', vocab_keywords=row['name'])
+        row['link'] = toolkit.url_for('dataset.search', vocab_keywords=row['name'])
 
     title = 'Keywords'
     return {

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -332,7 +332,7 @@ class UnhcrPlugin(
 
         try:
             blueprint, view = toolkit.get_endpoint()
-        except TypeError:
+        except (TypeError, RuntimeError):
             return search_params
 
         if blueprint in blueprints and view != 'edit':

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -93,7 +93,7 @@ def url_for(*args, **kw):
             and "/dataset/" in url
         ):
             url = url.replace('/dataset/', '/deposited-dataset/')
-    except TypeError:
+    except (TypeError, RuntimeError):
         pass
 
     return url

--- a/ckanext/unhcr/plugin.py
+++ b/ckanext/unhcr/plugin.py
@@ -228,6 +228,7 @@ class UnhcrPlugin(
             'get_max_resource_size': helpers.get_max_resource_size,
             'get_google_analytics_id': helpers.get_google_analytics_id,
             'nl_to_br': helpers.nl_to_br,
+            'is_plugin_loaded': helpers.is_plugin_loaded,
         }
 
     # IPackageController

--- a/ckanext/unhcr/templates/login_form.html
+++ b/ckanext/unhcr/templates/login_form.html
@@ -4,13 +4,15 @@
     <img src="/base/images/ckan-logo.png" alt="{{ g.site_title }}" title="{{ g.site_title }}" width="210" />
     {% endif %}
     <h2>{% trans %}You must be logged in to access the RIDL site.{% endtrans %}</h2>
-    <p>
-      <a class="btn btn-inverse btn-lg"
-        href="{{ h.url_for('saml2auth.saml2login', came_from=h.get_came_from_param()) }}"
-        title="Log in using your UNHCR Active Directory account">
-        Log in as UNHCR staff
-      </a>
-    </p>
+    {% if h.is_plugin_loaded('saml2auth') %}
+      <p>
+        <a class="btn btn-inverse btn-lg"
+          href="{{ h.url_for('saml2auth.saml2login', came_from=h.get_came_from_param()) }}"
+          title="Log in using your UNHCR Active Directory account">
+          Log in as UNHCR staff
+        </a>
+      </p>
+    {% endif %}
     <hr />
     <p>
       <a class="btn btn-inverse btn-lg"

--- a/ckanext/unhcr/templates/snippets/add_dataset_buttons.html
+++ b/ckanext/unhcr/templates/snippets/add_dataset_buttons.html
@@ -3,16 +3,20 @@
     <span >
       {% link_for _('Add Dataset'), named_route='dataset.new', class_='btn btn-primary', icon='plus-square', group=group %}
     </span>
-    <span>
-      {% link_for _('Import Dataset from DDI/XML'), named_route='ddi_import.import', class_='btn btn-primary', icon='plus-square', group=group  %}
-    </span>
+    {% if h.is_plugin_loaded('ddi_import') %}
+      <span>
+        {% link_for _('Import Dataset from DDI/XML'), named_route='ddi_import.import', class_='btn btn-primary', icon='plus-square', group=group  %}
+      </span>
+    {% endif %}
   {% else %}
     <span >
       {% link_for _('Add Dataset'), named_route='dataset.new', class_='btn btn-primary', icon='plus-square' %}
     </span>
-    <span>
-      {% link_for _('Import Dataset from DDI/XML'), named_route='ddi_import.import', class_='btn btn-primary', icon='plus-square' %}
-    </span>
+    {% if h.is_plugin_loaded('ddi_import') %}
+      <span>
+        {% link_for _('Import Dataset from DDI/XML'), named_route='ddi_import.import', class_='btn btn-primary', icon='plus-square' %}
+      </span>
+    {% endif %}
   {% endif %}
 </div>
 

--- a/ckanext/unhcr/templates/user/snippets/login_sidebar.html
+++ b/ckanext/unhcr/templates/user/snippets/login_sidebar.html
@@ -1,3 +1,4 @@
+{% if h.is_plugin_loaded('saml2auth') %}
 <section class="module module-narrow module-shallow">
   <h2 class="module-heading"><i class="fa fa-user"></i> UNHCR Staff</h2>
   <nav>
@@ -10,6 +11,7 @@
     </div>
   </nav>
 </section>
+{% endif %}
 
 <section class="module module-narrow module-shallow">
   <h2 class="module-heading"><i class="fa fa-user"></i> Partners</h2>

--- a/ckanext/unhcr/tests/mocks.py
+++ b/ckanext/unhcr/tests/mocks.py
@@ -1,5 +1,5 @@
 import cgi
-from StringIO import StringIO
+from io import BytesIO
 
 
 class FakeFileStorage(cgi.FieldStorage, object):
@@ -8,8 +8,8 @@ class FakeFileStorage(cgi.FieldStorage, object):
         super(FakeFileStorage, self).__init__()
         self.file = fp
         if not fp:
-            self.file = StringIO()
-            self.file.write('Some data')
+            self.file = BytesIO()
+            self.file.write(b'Some data')
 
         self.list = [self.file]
         self.filename = filename

--- a/ckanext/unhcr/tests/pt/actions/test_resource_actions.py
+++ b/ckanext/unhcr/tests/pt/actions/test_resource_actions.py
@@ -69,7 +69,7 @@ class TestResourceUpload(object):
                 package_id=dataset['id'],
                 url='https://example.com/some.data.csv'
             )
-        assert exc.value.error_dict.keys() == ['url']
+        assert list(exc.value.error_dict.keys()) == ['url']
 
         assert (
             exc.value.error_dict['url'] ==
@@ -97,7 +97,7 @@ class TestResourceUpload(object):
         with pytest.raises(toolkit.ValidationError) as exc:
             factories.Resource(package_id=dataset['id'])
 
-        assert exc.value.error_dict.keys() == ['url']
+        assert list(exc.value.error_dict.keys()) == ['url']
 
         assert (
             exc.value.error_dict['url'] ==

--- a/ckanext/unhcr/tests/pt/controllers/test_deposited_dataset.py
+++ b/ckanext/unhcr/tests/pt/controllers/test_deposited_dataset.py
@@ -99,7 +99,7 @@ class TestDepositedDatasetController(object):
 
     def make_request(self, action, dataset_id=None, user=None, **kwargs):
         url = '/deposited-dataset/%s/%s' % (
-            dataset_id or self.dataset['id'].encode('ascii'),
+            dataset_id or self.dataset['id'],
             action
         )
         env = {'REMOTE_USER': user.encode('ascii')} if user else {}

--- a/ckanext/unhcr/tests/pt/test_plugin.py
+++ b/ckanext/unhcr/tests/pt/test_plugin.py
@@ -35,7 +35,6 @@ class TestHooks(object):
         }
         self.new_resource_dict = {
             'package_id': self.dataset['id'],
-            'upload': mocks.FakeFileStorage(),
             'url': 'http://fakeurl/test.txt',
             'url_type': 'upload',
             'type': 'data',

--- a/ckanext/unhcr/validators.py
+++ b/ckanext/unhcr/validators.py
@@ -21,7 +21,7 @@ def ignore_if_attachment(key, data, errors, context):
 
 
 def _is_attachment(index, data):
-    for field, value in data.iteritems():
+    for field, value in data.items():
         if (field[0] == 'resources' and
                 field[1] == index and
                 field[2] == 'type' and

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 responses==0.12.1
 ckantoolkit>=0.0.3
-pytest
 pytest-ckan
 pytest-cov
+pytest<=6.2.2
+pytest-rerunfailures<=9.1.1


### PR DESCRIPTION
Closes #612
Refs https://github.com/okfn/docker-ckan-unhcr-aws/pull/48

- I rolled back the commit which run the python3 tests on master in https://github.com/okfn/ckanext-unhcr/commit/d4b9d9aad31bcd757c0b9e297a936d96e84be3c0 Merging this PR will drop python2 compatibility and testing completely

- This PR gets us to the stage where all the tests pass on python3 I also did a load of manual testing and couldn't find any further issues

- There are various other bits of python2 cruft which I have chosen not to remove yet. For example, we can change all the `import mock` statements to `from unittest import mock`. We can remove all the `# -*- coding: utf-8 -*-` statements. We can also drop any leading `u`s from strings (i.e: `u'things'` --> `'things'`) etc. I have decided not to do these yet. Since we may end up "maintaining" this diff alongside master for a while I want to keep the changeset as small as possible: minimum viable python3-compatibility, if you will :) We can do this kind of "cleanup" in a follow-on PR