### PR TITLE
Skip missing API key error

### DIFF
--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -1259,9 +1259,9 @@ def user_update(up_func, context, data_dict):
 
     if user_obj is not None and is_saml2_user(user_obj):
 
-        if user_obj.apikey != data_dict.get('apikey'):
+        if data_dict.get('apikey') and user_obj.apikey != data_dict.get('apikey'):
             up_dict = toolkit.get_action('user_show')(context.copy(), {'id': user_id})
-            up_dict['apikey'] = data_dict['apikey']
+            up_dict['apikey'] = data_dict.get('apikey')
             return up_func(context, up_dict)
 
         raise toolkit.ValidationError({'error': [


### PR DESCRIPTION
Fixes this error

```
2021-07-14T09:26:04.005-03:00 | 2021-07-14 12:26:04,005 WARNI [saml2.client_base] The SAML service provider accepts unsigned SAML Responses and Assertions. This configuration is insecure. Consider setting want_assertions_signed, want_response_signed or want_assertions_or_response_signed configuration options.

  | 2021-07-14T09:26:04.063-03:00 | 2021-07-14 12:26:04,062 ERROR [ckan.config.middleware.flask_app] 'apikey'
  | 2021-07-14T09:26:04.063-03:00 | Traceback (most recent call last):
  | 2021-07-14T09:26:04.063-03:00 | File "/usr/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
  | 2021-07-14T09:26:04.063-03:00 | rv = self.dispatch_request()
  | 2021-07-14T09:26:04.063-03:00 | File "/usr/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
  | 2021-07-14T09:26:04.063-03:00 | return self.view_functions[rule.endpoint](**req.view_args)
  | 2021-07-14T09:26:04.063-03:00 | File "/srv/app/src/ckanext-saml2auth/ckanext/saml2auth/views/saml2auth.py", line 231, in acs
  | 2021-07-14T09:26:04.063-03:00 | g.user = process_user(email, saml_id, full_name, auth_response.ava)
  | 2021-07-14T09:26:04.063-03:00 | File "/srv/app/src/ckanext-saml2auth/ckanext/saml2auth/views/saml2auth.py", line 150, in process_user
  | 2021-07-14T09:26:04.063-03:00 | user_dict = _update_user(user_dict)
  | 2021-07-14T09:26:04.063-03:00 | File "/srv/app/src/ckanext-saml2auth/ckanext/saml2auth/views/saml2auth.py", line 75, in _update_user
  | 2021-07-14T09:26:04.063-03:00 | return toolkit.get_action(u'user_update')(context, user_dict)
  | 2021-07-14T09:26:04.063-03:00 | File "/srv/app/src/ckan/ckan/logic/__init__.py", line 477, in wrapped
  | 2021-07-14T09:26:04.063-03:00 | result = _action(context, data_dict, **kw)
  | 2021-07-14T09:26:04.063-03:00 | File "/srv/app/src/ckanext-unhcr/ckanext/unhcr/actions.py", line 1264, in user_update
  | 2021-07-14T09:26:04.063-03:00 | up_dict['apikey'] = data_dict['apikey']
  | 2021-07-14T09:26:04.063-03:00 | KeyError: 'apikey'
```
