### PR TITLE
add some extra CI checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,18 @@ jobs:
       - name: Initialize DB
         run: ./bin/init-db.bash
 
+      - name: Ensure assets are up-to-date
+        run: |
+          apk add --update npm
+          npm ci
+          make assets
+          git diff --exit-code ./ckanext/unhcr/fanstatic
+
+      - name: Ensure deposited_dataset schema is up-to-date
+        run: |
+          python3 scripts/generate_deposited_dataset_schema.py
+          git diff --exit-code ./ckanext/unhcr/schemas
+
       - name: Run tests
         run: |
           pytest \


### PR DESCRIPTION
This PR adds two additional CI checks which will cause the build to fail if we have:

- Updated SASS/JS files but forgotten to compile them with `make assets`
- Updated the dataset schema but forgotten to compile the deposited_dataset schema

example fails:
https://github.com/okfn/ckanext-unhcr/runs/3161067230?check_suite_focus=true
https://github.com/okfn/ckanext-unhcr/runs/3161123176?check_suite_focus=true