### PR TITLE
Fix kobo cache for users changing token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # RIDL Changelog
 
+## v3.1.7.3 - 2022-06-XX
+Bug Fixes
+ - Fix kobo cache when user changes its token [#818](https://github.com/okfn/ckanext-unhcr/pull/818)
+
 ## v3.1.7a - 2022-05-06 - PRODUCTION HOTFIX
 Single commit applyed to 3.1.7
  - Error showing KoBo datasets for non-KoBo users. [Cherry-pick](https://github.com/okfn/ckanext-unhcr/pull/810/commits/a8244d2fa5f40c31b702651dcd89fbb332e69a58) from [#810](https://github.com/okfn/ckanext-unhcr/pull/810)

--- a/ckanext/unhcr/actions.py
+++ b/ckanext/unhcr/actions.py
@@ -1666,7 +1666,7 @@ def user_update(up_func, context, data_dict):
                     if context.get('validate_token', True):
                         # check if the token is valid
                         kobo_url = toolkit.config.get('ckanext.unhcr.kobo_url', 'https://kobo.unhcr.org')
-                        kobo = KoBoAPI(new_kobo_token, kobo_url, cache_prefix=user_obj.name)
+                        kobo = KoBoAPI(new_kobo_token, kobo_url)
                         if not kobo.test_token():
                             raise toolkit.ValidationError({'kobo_token': [
                                 "KoBoToolbox token is not valid"

--- a/ckanext/unhcr/auth.py
+++ b/ckanext/unhcr/auth.py
@@ -200,7 +200,7 @@ def package_kobo_update(context, data_dict):
     if not kobo_token:
         return {'success': False, 'msg': 'KoBo token is not defined'}
     kobo_url = toolkit.config.get('ckanext.unhcr.kobo_url', 'https://kobo.unhcr.org')
-    kobo_api = KoBoAPI(kobo_token, kobo_url, cache_prefix=user_obj.name)
+    kobo_api = KoBoAPI(kobo_token, kobo_url)
     survey = kobo_api.get_asset(kobo_asset_id)
     if survey['user_is_manager']:
         return {'success': True}

--- a/ckanext/unhcr/blueprints/kobo.py
+++ b/ckanext/unhcr/blueprints/kobo.py
@@ -107,7 +107,7 @@ def kobo_surveys():
 
     # check if the token is valid
     kobo_url = toolkit.config.get('ckanext.unhcr.kobo_url', 'https://kobo.unhcr.org')
-    kobo = KoBoAPI(token, kobo_url, cache_prefix=user_obj.name)
+    kobo = KoBoAPI(token, kobo_url)
 
     try:
         surveys = kobo.get_surveys()

--- a/ckanext/unhcr/jobs.py
+++ b/ckanext/unhcr/jobs.py
@@ -322,7 +322,7 @@ def _prepare_kobo_download(resource_id):
     plugin_extras = {} if user_obj.plugin_extras is None else user_obj.plugin_extras
     kobo_token = plugin_extras.get('unhcr', {}).get('kobo_token')
     kobo_url = toolkit.config.get('ckanext.unhcr.kobo_url', 'https://kobo.unhcr.org')
-    kobo_api = KoBoAPI(kobo_token, kobo_url, cache_prefix=user_obj.name)
+    kobo_api = KoBoAPI(kobo_token, kobo_url)
 
     kobo_asset_id = kobo_details['kobo_asset_id']
     kd = KoboDataset(kobo_asset_id)

--- a/ckanext/unhcr/kobo/api.py
+++ b/ckanext/unhcr/kobo/api.py
@@ -18,14 +18,12 @@ class KoBoAPI:
     """ About KoBo API
         https://support.kobotoolbox.org/api.html
     """
-    def __init__(self, token, kobo_url, cache_prefix):
+    def __init__(self, token, kobo_url):
         self.token = token
         self.kobo_url = kobo_url
         self.base_url = '{}/api/v2/'.format(kobo_url)
         self.surveys = None
         self._user = None
-        # We use RIDL user name as prefix because we call same URL for different users
-        self.cache_prefix = cache_prefix
         self.cache_seconds = int(config.get('ckanext.unhcr.kobo_cache_seconds', '600'))
         redis_url = config.get('ckan.redis.url', 'redis://localhost:6379/0')
         if self.cache_seconds == 0:
@@ -47,15 +45,15 @@ class KoBoAPI:
         logger.info('Getting KoBoToolbox resource: {}'.format(resource_url))
         if return_json:
             if self.cache and not force:
-                # Different users calls the same URLs so we need to use the users as a part of the cache key
-                cache_name = '{}__{}'.format(self.cache_prefix, url)
+                # Different users calls the same URLs so we need unique cache keys
+                cache_name = '{}__{}'.format(self.token, url)
                 cache_key = base64.b64encode(cache_name.encode())
                 if self.cache.get(cache_key):
                     data = json.loads(self.cache.get(cache_key))
-                    logger.info('Using cache for KoBo response: {} :: {}'.format(self.cache_prefix, resource_url))
+                    logger.info('Using cache for KoBo response: {}'.format(resource_url))
                     return data
 
-            logger.info('Resource not cached: {} :: {}'.format(self.cache_prefix, resource_url))
+            logger.info('Resource not cached: {}'.format(resource_url))
 
         try:
             response = requests.get(url, headers={'Authorization': 'Token ' + self.token})

--- a/ckanext/unhcr/kobo/api.py
+++ b/ckanext/unhcr/kobo/api.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -46,7 +47,9 @@ class KoBoAPI:
         if return_json:
             if self.cache and not force:
                 # Different users calls the same URLs so we need unique cache keys
-                cache_name = '{}__{}'.format(self.token, url)
+                # For security, we don't use the token as is.
+                hashed_token = hashlib.sha256(self.token.encode('utf-8')).hexdigest()
+                cache_name = '{}__{}'.format(hashed_token, url)
                 cache_key = base64.b64encode(cache_name.encode())
                 if self.cache.get(cache_key):
                     data = json.loads(self.cache.get(cache_key))

--- a/ckanext/unhcr/kobo/kobo_dataset.py
+++ b/ckanext/unhcr/kobo/kobo_dataset.py
@@ -121,7 +121,7 @@ class KoboDataset:
             if not kobo_token:
                 raise KoBoUserTokenMissingError()
             kobo_url = toolkit.config.get('ckanext.unhcr.kobo_url', 'https://kobo.unhcr.org')
-            self.kobo_api = KoBoAPI(kobo_token, kobo_url, cache_prefix=user_obj.name)
+            self.kobo_api = KoBoAPI(kobo_token, kobo_url)
 
         return self.kobo_api
 


### PR DESCRIPTION
Related to #813 

Use kobo token as prefix instead user name to avoid cache errors when user changes its token.