### PR TITLE
Show proper value for geographies in dataset form

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # RIDL Changelog
 
+## v3.1.7.3 - 2022-06-XX
+Bug fixes
+ - Fix geography field view after dataset form validation error [#822](https://github.com/okfn/ckanext-unhcr/pull/822)
+
 ## v3.1.7a - 2022-05-06 - PRODUCTION HOTFIX
 Single commit applyed to 3.1.7
  - Error showing KoBo datasets for non-KoBo users. [Cherry-pick](https://github.com/okfn/ckanext-unhcr/pull/810/commits/a8244d2fa5f40c31b702651dcd89fbb332e69a58) from [#810](https://github.com/okfn/ckanext-unhcr/pull/810)

--- a/ckanext/unhcr/templates/scheming/form_snippets/geographies.html
+++ b/ckanext/unhcr/templates/scheming/form_snippets/geographies.html
@@ -7,6 +7,7 @@
   <label class="control-label" for="field-geographies">{{ field.label }}</label>
 
   {% set unspecified = [h.get_default_geography()] == data[field.field_name] %}
+  {% set val = data[field.field_name] if data[field.field_name] is string else data[field.field_name]|join(',') %}
   
   <div class="controls {% if unspecified %}unspecified-geo-div{% endif %}">
     {% if unspecified %}
@@ -25,7 +26,7 @@
       data-module-key="pcode"
       data-module-label="name"
       data-module-minimum-input-length="2"
-      value="{{ data[field.field_name]|join(',') }}"
+      value="{{ val }}"
       placeholder="{% if unspecified %}Please provide at least country-level geographic coverage{% else %}{{ field.form_placeholder }}{% endif %}"
     />
     <div class="info-block ">


### PR DESCRIPTION
Related to #811 

When we have validation errors for a dataset, the geographies fields returns as a string (not a list) and we are not able to properly show them