### PR TITLE
Avoid errors on unexpected KoBo settings structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # RIDL Changelog
 
+## v3.1.7.3 - 2022-06-XX
+Bug fixes
+ - Avoid errors on unexpected KoBo "settings" structure [#824](https://github.com/okfn/ckanext-unhcr/pull/824)
+
 ## v3.1.7a - 2022-05-06 - PRODUCTION HOTFIX
 Single commit applyed to 3.1.7
  - Error showing KoBo datasets for non-KoBo users. [Cherry-pick](https://github.com/okfn/ckanext-unhcr/pull/810/commits/a8244d2fa5f40c31b702651dcd89fbb332e69a58) from [#810](https://github.com/okfn/ckanext-unhcr/pull/810)

--- a/ckanext/unhcr/kobo/kobo_dataset.py
+++ b/ckanext/unhcr/kobo/kobo_dataset.py
@@ -156,11 +156,17 @@ class KoboDataset:
 
         sector = asset['settings'].get('sector')
         if sector:
-            starting_notes += '\nSector: {}'.format(sector['label'])
+            # KoBo "settings" field is a JSON field. We can't be sure in its internal structure
+            # Check https://github.com/okfn/ckanext-unhcr/issues/823
+            if type(sector) == dict:
+                starting_notes += '\nSector: {}'.format(sector['label'])
 
         country = asset['settings'].get('country')
         if country:
-            starting_notes += '\nCountry: {} ({})'.format(country['label'], country['value'])
+            # KoBo "settings" field is a JSON field. We can't be sure in its internal structure
+            # Check https://github.com/okfn/ckanext-unhcr/issues/823
+            if type(country) == dict:
+                starting_notes += '\nCountry: {} ({})'.format(country['label'], country['value'])
 
         original_description = asset['settings'].get('description')
         if original_description:


### PR DESCRIPTION
Related to #823 

Skip unexpected data from KoBo in the automatic description field.